### PR TITLE
Implement custom IFP animations

### DIFF
--- a/Client/game_sa/CAnimBlendAssocGroupSA.cpp
+++ b/Client/game_sa/CAnimBlendAssocGroupSA.cpp
@@ -18,6 +18,22 @@ CAnimBlendAssocGroupSA::CAnimBlendAssocGroupSA(CAnimBlendAssocGroupSAInterface* 
     SetupAnimBlock();
 }
 
+CAnimBlendAssociationSAInterface* CAnimBlendAssocGroupSA::CopyAnimation(unsigned int AnimID)
+{
+    CAnimBlendAssociationSAInterface* pAnimAssociationReturn = nullptr;
+
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendAssocGroup_CopyAnimation;
+    _asm
+    {
+        mov     ecx, dwThis
+        push    AnimID
+        call    dwFunc
+        mov     pAnimAssociationReturn, eax
+    }
+    return pAnimAssociationReturn;
+}
+
 void CAnimBlendAssocGroupSA::InitEmptyAssociations(RpClump* pClump)
 {
     DWORD dwThis = (DWORD)m_pInterface;

--- a/Client/game_sa/CAnimBlendAssocGroupSA.h
+++ b/Client/game_sa/CAnimBlendAssocGroupSA.h
@@ -17,6 +17,7 @@
 #include "Common.h"
 
 #define FUNC_CAnimBlendAssocGroup_InitEmptyAssociations 0x4cdfb0
+#define FUNC_CAnimBlendAssocGroup_CopyAnimation         0x4ce130
 #define FUNC_CAnimBlendAssocGroup_IsCreated             0x4d37a0
 #define FUNC_CAnimBlendAssocGroup_GetNumAnimations      0x45b050
 #define FUNC_CAnimBlendAssocGroup_GetAnimBlock          0x45b060
@@ -44,12 +45,14 @@ class CAnimBlendAssocGroupSA : public CAnimBlendAssocGroup
 public:
     CAnimBlendAssocGroupSA(CAnimBlendAssocGroupSAInterface* pInterface);
 
-    void                         InitEmptyAssociations(RpClump* pClump);
-    bool                         IsCreated(void);
-    int                          GetNumAnimations(void);
-    CAnimBlock*                  GetAnimBlock(void);
-    CAnimBlendStaticAssociation* GetAnimation(unsigned int ID);
-    void                         CreateAssociations(const char* szBlockName);
+    CAnimBlendAssociationSAInterface* CopyAnimation(unsigned int AnimID);
+    void                              InitEmptyAssociations(RpClump* pClump);
+    bool                              IsCreated(void);
+    int                               GetNumAnimations(void);
+    CAnimBlock*                       GetAnimBlock(void);
+    CAnimBlendStaticAssociation*      GetAnimation(unsigned int ID);
+    AssocGroupId                      GetGroupID(void) { return m_pInterface->groupID; };
+    void                              CreateAssociations(const char* szBlockName);
 
     bool IsLoaded(void);
     void SetIDOffset(int iOffset) { m_pInterface->iIDOffset = iOffset; }

--- a/Client/game_sa/CAnimBlendAssociationSA.h
+++ b/Client/game_sa/CAnimBlendAssociationSA.h
@@ -35,6 +35,9 @@ public:
     short                           sAnimID;                        // 44
     short                           sFlags;                         // or1 = started?, or64 = referenced?   // 46
     DWORD*                          pCallback;                      // 48
+    DWORD*                          pCallbackFunc;                  // 52
+    DWORD*                          pCallbackData;                  // 56
+                                                                    // Total: 60 bytes
 };
 
 class CAnimBlendAssociationSA : public CAnimBlendAssociation

--- a/Client/game_sa/CAnimBlendHierarchySA.cpp
+++ b/Client/game_sa/CAnimBlendHierarchySA.cpp
@@ -11,7 +11,81 @@
 
 #include "StdInc.h"
 
+// Careful, GetIndex will not work for custom animations
 int CAnimBlendHierarchySAInterface::GetIndex(void)
 {
     return (((DWORD)this - ARRAY_CAnimManager_Animations) / 24);
+}
+
+void CAnimBlendHierarchySA::Initialize(void)
+{
+    m_pInterface->pSequences = 0;
+    m_pInterface->usNumSequences = 0;
+    m_pInterface->bRunningCompressed = 0;
+    m_pInterface->pad = 0;
+    m_pInterface->iAnimBlockID = -1;
+    m_pInterface->fTotalTime = 0;
+    m_pInterface->pLinkPtr = 0;
+}
+
+void CAnimBlendHierarchySA::SetName(const char* szName)
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendHierarchy_SetName;
+    _asm
+    {
+        push    szName
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}
+
+void CAnimBlendHierarchySA::RemoveAnimSequences(void)
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveAnimSequences;
+    _asm
+    {
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}
+
+void CAnimBlendHierarchySA::RemoveFromUncompressedCache(void)
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveFromUncompressedCache;
+    _asm
+    {
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}
+
+void CAnimBlendHierarchySA::RemoveQuaternionFlips(void)
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveQuaternionFlips;
+    _asm
+    {
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}
+
+void CAnimBlendHierarchySA::CalculateTotalTime(void)
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendHierarchy_CalculateTotalTime;
+    _asm
+    {
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}
+
+CAnimBlendSequenceSAInterface* CAnimBlendHierarchySA::GetSequence(DWORD dwIndex)
+{
+    BYTE* pSequences = reinterpret_cast<BYTE*>(m_pInterface->pSequences);
+    return reinterpret_cast<CAnimBlendSequenceSAInterface*>(pSequences + (sizeof(CAnimBlendSequenceSAInterface) * dwIndex));
 }

--- a/Client/game_sa/CAnimBlendHierarchySA.h
+++ b/Client/game_sa/CAnimBlendHierarchySA.h
@@ -17,22 +17,30 @@
 #include <game/CAnimBlendHierarchy.h>
 #include "Common.h"
 
-#define FUNC_CAnimBlendHierarchy_GetAnimSequence    0x4ce8f0
-#define FUNC_CAnimBlendHierarchy_GetAnimSequences   0x4d1350
+#define FUNC_CAnimBlendHierarchy_SetName                     0x4CF2D0
+#define FUNC_CAnimBlendHierarchy_RemoveAnimSequences         0x4CF8E0
+#define FUNC_CAnimBlendHierarchy_RemoveFromUncompressedCache 0x4D42A0
+#define FUNC_CAnimBlendHierarchy_RemoveQuaternionFlips       0x4CF4E0
+#define FUNC_CAnimBlendHierarchy_CalculateTotalTime          0x4CF2F0
+#define FUNC_CAnimBlendHierarchy_GetAnimSequence             0x4ce8f0
+#define FUNC_CAnimBlendHierarchy_GetAnimSequences            0x4d1350
 
 class CAnimBlendSequence;
 
 class CAnimBlendHierarchySAInterface
 {
 public:
-    int                 GetIndex(void);
-    int                 iHashKey;
-    CAnimBlendSequence* pSequences;
-    unsigned short      usNumSequences;
-    BYTE                pad;
-    bool                bRunningCompressed;
-    int                 iAnimBlockID;
-    float               fTotalTime;
+    // Careful, GetIndex will not work for custom animations
+    int GetIndex(void);
+
+    unsigned int                   iHashKey;
+    CAnimBlendSequenceSAInterface* pSequences;
+    unsigned short                 usNumSequences;
+    bool                           bRunningCompressed;
+    BYTE                           pad;
+    int                            iAnimBlockID;
+    float                          fTotalTime;
+    DWORD*                         pLinkPtr;
     // class CLink<class CAnimBlendHierarchy *> *      pLinkPtr;
 };
 
@@ -40,9 +48,22 @@ class CAnimBlendHierarchySA : public CAnimBlendHierarchy
 {
 public:
     CAnimBlendHierarchySA(CAnimBlendHierarchySAInterface* pInterface) { m_pInterface = pInterface; }
-
-    CAnimBlendHierarchySAInterface* GetInterface(void) { return m_pInterface; }
+    void                            Initialize(void);
+    void                            SetName(const char* szName);
+    void                            SetSequences(CAnimBlendSequenceSAInterface* pSequences) { m_pInterface->pSequences = pSequences; }
+    void                            SetNumSequences(unsigned short uNumSequences) { m_pInterface->usNumSequences = uNumSequences; }
+    void                            SetRunningCompressed(bool bCompressed) { m_pInterface->bRunningCompressed = bCompressed; }
+    void                            SetAnimationBlockID(int iBlockID) { m_pInterface->iAnimBlockID = iBlockID; }
+    void                            RemoveAnimSequences(void);
+    void                            RemoveFromUncompressedCache(void);
+    void                            RemoveQuaternionFlips(void);
+    void                            CalculateTotalTime(void);
+    CAnimBlendSequenceSAInterface*  GetSequence(DWORD dwIndex);
+    CAnimBlendSequenceSAInterface*  GetSequences(void) { return m_pInterface->pSequences; }
+    unsigned short                  GetNumSequences(void) { return m_pInterface->usNumSequences; }
+    bool                            isRunningCompressed(void) { return m_pInterface->bRunningCompressed; }
     int                             GetAnimBlockID(void) { return m_pInterface->iAnimBlockID; }
+    CAnimBlendHierarchySAInterface* GetInterface(void) { return m_pInterface; }
 
 protected:
     CAnimBlendHierarchySAInterface* m_pInterface;

--- a/Client/game_sa/CAnimBlendSequenceSA.cpp
+++ b/Client/game_sa/CAnimBlendSequenceSA.cpp
@@ -10,3 +10,60 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+
+void CAnimBlendSequenceSA::Initialize(void)
+{
+    m_pInterface->m_boneId = -1;
+    m_pInterface->sFlags = 0;
+    m_pInterface->sNumKeyFrames = 0;
+    m_pInterface->pKeyFrames = 0;
+}
+
+void CAnimBlendSequenceSA::SetName(const char* szName)
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendSequence_SetName;
+    _asm
+    {
+        push    szName
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}
+
+void CAnimBlendSequenceSA::SetBoneTag(int32_t i32BoneID)
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendSequence_SetBoneTag;
+    _asm
+    {
+        push    i32BoneID
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}
+
+void CAnimBlendSequenceSA::SetKeyFrames(size_t cKeyFrames, bool bRoot, bool bCompressed, void* pKeyFrames)
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendSequence_SetKeyFrames;
+    _asm
+    {
+        push    pKeyFrames
+        push    bCompressed
+        push    bRoot
+        push    cKeyFrames
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}
+
+void CAnimBlendSequenceSA::CopySequenceProperties(CAnimBlendSequenceSAInterface* pAnimSequenceInterface)
+{
+    *m_pInterface = *pAnimSequenceInterface;
+}
+
+void* CAnimBlendSequenceSA::GetKeyFrame(size_t iFrame, uint32_t u32FrameSizeInBytes)
+{
+    return (m_pInterface->pKeyFrames + u32FrameSizeInBytes * iFrame);
+}

--- a/Client/game_sa/CAnimBlendSequenceSA.h
+++ b/Client/game_sa/CAnimBlendSequenceSA.h
@@ -14,19 +14,38 @@
 
 #include <game/CAnimBlendSequence.h>
 
+#define FUNC_CAnimBlendSequence_SetName      0x4D0C50
+#define FUNC_CAnimBlendSequence_SetBoneTag   0x4D0C70
+#define FUNC_CAnimBlendSequence_SetKeyFrames 0x4D0CD0
+
 class CAnimBlendSequenceSAInterface
 {
 public:
-    unsigned int              iHashKey;                 // Get/SetBoneTag accesses the first? 2 bytes here
-    short                     sFlags;                   // 4    // or16=bHasBoneTag
-    short                     sNumKeyFrames;            // 6
-    class CAnimBlendKeyFrame* pKeyFrames;               // ?
+    union {
+        uint16_t m_boneId;            // m_boneId is set if ( sFlags & 0x10u ) is true
+        uint32_t m_hash;              // otherwise m_hash is set
+    };
+    unsigned short sFlags;
+    unsigned short sNumKeyFrames;
+    BYTE*          pKeyFrames;
 };
 
 class CAnimBlendSequenceSA : public CAnimBlendSequence
 {
 public:
     CAnimBlendSequenceSA(CAnimBlendSequenceSAInterface* pInterface) { m_pInterface = pInterface; }
+    void                           Initialize(void);
+    void                           SetName(const char* szName);
+    void                           SetBoneTag(int32_t i32BoneID);
+    void                           SetKeyFrames(size_t cKeyFrames, bool bRoot, bool bCompressed, void* pKeyFrames);
+    void*                          GetKeyFrame(size_t iFrame, uint32_t u32FrameSizeInBytes);
+    uint32_t                       GetHash(void) { return m_pInterface->m_hash; }
+    uint16_t                       GetBoneTag(void) { return m_pInterface->m_boneId; }
+    BYTE*                          GetKeyFrames(void) { return m_pInterface->pKeyFrames; }
+    unsigned short                 GetKeyFramesCount(void) { return m_pInterface->sNumKeyFrames; }
+    bool                           IsBigChunkForAllSequences(void) { return ((m_pInterface->sFlags >> 3) & 1); }
+    void                           CopySequenceProperties(CAnimBlendSequenceSAInterface* pAnimSequenceInterface);
+    CAnimBlendSequenceSAInterface* GetInterface(void) { return m_pInterface; }
 
 protected:
     CAnimBlendSequenceSAInterface* m_pInterface;

--- a/Client/game_sa/CAnimBlendStaticAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendStaticAssociationSA.cpp
@@ -11,7 +11,15 @@
 
 #include "StdInc.h"
 
-CAnimBlendHierarchy* CAnimBlendStaticAssociationSA::GetAnimHierachy(void)
+void CAnimBlendStaticAssociationSA::Initialize(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimBlendHierarchyInterface)
 {
-    return NULL;
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAnimBlendStaticAssociation_Initialize;
+    _asm
+    {
+        push    pAnimBlendHierarchyInterface
+        push    pClump
+        mov     ecx, dwThis
+        call    dwFunc
+    }
 }

--- a/Client/game_sa/CAnimBlendStaticAssociationSA.h
+++ b/Client/game_sa/CAnimBlendStaticAssociationSA.h
@@ -17,18 +17,23 @@
 #include <game/CAnimBlendStaticAssociation.h>
 #include "Common.h"
 
+#define FUNC_CAnimBlendStaticAssociation_Initialize 0x4CEC20
+
 class CAnimBlendAssocGroupSA;
 class CAnimBlendHierarchySAInterface;
 class CAnimBlendHierarchy;
 
 class CAnimBlendStaticAssociationSAInterface
 {
+protected:
+    void* vTable;
+
 public:
-    BYTE                            pad[6];
+    unsigned short                  nNumBlendNodes;
     short                           sAnimID;
     short                           sAnimGroup;
     short                           sFlags;
-    BYTE                            pad2[4];
+    int*                            pAnimBlendNodesSequenceArray;
     CAnimBlendHierarchySAInterface* pAnimHeirarchy;
 };
 
@@ -36,8 +41,17 @@ class CAnimBlendStaticAssociationSA : public CAnimBlendStaticAssociation
 {
 public:
     CAnimBlendStaticAssociationSA(CAnimBlendStaticAssociationSAInterface* pInterface) { m_pInterface = pInterface; }
+    void Initialize(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimBlendHierarchyInterface);
+    void SetNumBlendNodes(unsigned short nNumBlendNodes) { m_pInterface->nNumBlendNodes = nNumBlendNodes; };
+    void SetAnimID(short sAnimID) { m_pInterface->sAnimID = sAnimID; }
+    void SetAnimGroup(short sAnimGroup) { m_pInterface->sAnimGroup = sAnimGroup; }
+    void SetFlags(short sFlags) { m_pInterface->sFlags = sFlags; }
 
-    CAnimBlendHierarchy* GetAnimHierachy(void);
+    unsigned short                  GetNumBlendNodes(void) { return m_pInterface->nNumBlendNodes; };
+    short                           GetAnimID(void) { return m_pInterface->sAnimID; }
+    short                           GetAnimGroup(void) { return m_pInterface->sAnimGroup; }
+    short                           GetFlags(void) { return m_pInterface->sFlags; }
+    CAnimBlendHierarchySAInterface* GetAnimHierachyInterface(void) { return m_pInterface->pAnimHeirarchy; }
 
 protected:
     CAnimBlendStaticAssociationSAInterface* m_pInterface;

--- a/Client/game_sa/CAnimBlockSA.cpp
+++ b/Client/game_sa/CAnimBlockSA.cpp
@@ -43,3 +43,13 @@ void CAnimBlockSA::Request(EModelRequestType requestType, bool bAllowBlockingFai
         AddRef();
     }
 }
+
+CAnimBlendHierarchySAInterface* CAnimBlockSA::GetAnimationHierarchyInterface(size_t iAnimation)
+{
+    if (!IsLoaded())
+        return nullptr;
+
+    iAnimation += m_pInterface->idOffset;
+    BYTE* arrAnimations = reinterpret_cast<BYTE*>(ARRAY_CAnimManager_Animations);
+    return reinterpret_cast<CAnimBlendHierarchySAInterface*>(arrAnimations + sizeof(CAnimBlendHierarchySAInterface) * iAnimation);
+}

--- a/Client/game_sa/CAnimBlockSA.h
+++ b/Client/game_sa/CAnimBlockSA.h
@@ -26,7 +26,9 @@ public:
     bool           bLoaded;            // ?
     BYTE           pad[1];
     unsigned short usRefs;
-    BYTE           pad2[12];
+    int            idOffset;
+    size_t         nAnimations;
+    DWORD          dwAssocGroup;
 };
 
 class CAnimBlockSA : public CAnimBlock
@@ -36,13 +38,16 @@ class CAnimBlockSA : public CAnimBlock
 public:
     CAnimBlockSA(CAnimBlockSAInterface* pInterface) { m_pInterface = pInterface; }
 
-    CAnimBlockSAInterface* GetInterface(void) { return m_pInterface; }
-    char*                  GetName(void) { return m_pInterface->szName; }
-    int                    GetIndex(void) { return m_pInterface->GetIndex(); }
-    void                   AddRef(void) { m_pInterface->usRefs++; }
-    unsigned short         GetRefs(void) { return m_pInterface->usRefs; }
-    void                   Request(EModelRequestType requestType, bool bAllowBlockingFail = false);
-    bool                   IsLoaded(void) { return m_pInterface->bLoaded; }
+    CAnimBlockSAInterface*          GetInterface(void) { return m_pInterface; }
+    char*                           GetName(void) { return m_pInterface->szName; }
+    int                             GetIndex(void) { return m_pInterface->GetIndex(); }
+    void                            AddRef(void) { m_pInterface->usRefs++; }
+    unsigned short                  GetRefs(void) { return m_pInterface->usRefs; }
+    bool                            IsLoaded(void) { return m_pInterface->bLoaded; }
+    int                             GetIDOffset(void) { return m_pInterface->idOffset; }
+    size_t                          GetAnimationCount(void) { return m_pInterface->nAnimations; }
+    void                            Request(EModelRequestType requestType, bool bAllowBlockingFail = false);
+    CAnimBlendHierarchySAInterface* GetAnimationHierarchyInterface(size_t iAnimation);
 
 protected:
     CAnimBlockSAInterface* m_pInterface;

--- a/Client/game_sa/CAnimManagerSA.h
+++ b/Client/game_sa/CAnimManagerSA.h
@@ -19,6 +19,7 @@
 
 #include "Common.h"
 #include <list>
+#include <map>
 
 #define FUNC_CAnimManager_Initialize                        0x5bf6b0
 #define FUNC_CAnimManager_Shutdown                          0x4d4130
@@ -55,6 +56,8 @@
 #define FUNC_CAnimManager_LoadAnimFile                      0x4d55d0
 #define FUNC_CAnimManager_LoadAnimFile_stream               0x4d47f0
 #define FUNC_CAnimManager_LoadAnimFiles                     0x4d5620
+#define FUNC_CAnimManager_AllocateKeyFramesMemory           0x72F420
+#define FUNC_CAnimManager_FreeKeyFramesMemory               0x72F430
 #define ARRAY_CAnimManager_AnimAssocGroups                  0xb4ea34
 #define ARRAY_CAnimManager_Animations                       0xb4ea40
 #define ARRAY_CAnimManager_AnimBlocks                       0xb5d4a0
@@ -77,6 +80,8 @@ public:
 
 class CAnimManagerSA : public CAnimManager
 {
+    typedef std::unique_ptr<CAnimBlendStaticAssociation> StaticAssocIntface_type;
+
 public:
     CAnimManagerSA(void);
     ~CAnimManagerSA(void);
@@ -103,14 +108,14 @@ public:
     const char *GetAnimGroupName(AssocGroupId groupID);
     const char *GetAnimBlockName(AssocGroupId groupID);
 
-    CAnimBlendAssociation *CreateAnimAssociation(AssocGroupId animGroup, AnimationId animID);
-    CAnimBlendAssociation *GetAnimAssociation(AssocGroupId animGroup, AnimationId animID);
-    CAnimBlendAssociation *GetAnimAssociation(AssocGroupId animGroup, const char *szAnimName);
-    CAnimBlendAssociation *AddAnimation(RpClump *pClump, AssocGroupId animGroup, AnimationId animID);
-    CAnimBlendAssociation *AddAnimation(RpClump *pClump, CAnimBlendHierarchy *, int ID);
-    CAnimBlendAssociation *AddAnimationAndSync(RpClump *pClump, CAnimBlendAssociation *pAssociation, AssocGroupId animGroup, AnimationId animID);
-    CAnimBlendAssociation *BlendAnimation(RpClump *pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta);
-    CAnimBlendAssociation *BlendAnimation(RpClump *pClump, CAnimBlendHierarchy *pHierarchy, int ID, float fBlendDelta);
+    CAnimBlendAssociation * CreateAnimAssociation(AssocGroupId animGroup, AnimationId animID);
+    StaticAssocIntface_type GetAnimStaticAssociation(AssocGroupId animGroup, AnimationId animID);
+    CAnimBlendAssociation * GetAnimAssociation(AssocGroupId animGroup, const char *szAnimName);
+    CAnimBlendAssociation * AddAnimation(RpClump *pClump, AssocGroupId animGroup, AnimationId animID);
+    CAnimBlendAssociation * AddAnimation(RpClump *pClump, CAnimBlendHierarchy *, int ID);
+    CAnimBlendAssociation * AddAnimationAndSync(RpClump *pClump, CAnimBlendAssociation *pAssociation, AssocGroupId animGroup, AnimationId animID);
+    CAnimBlendAssociation * BlendAnimation(RpClump *pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta);
+    CAnimBlendAssociation * BlendAnimation(RpClump *pClump, CAnimBlendHierarchy *pHierarchy, int ID, float fBlendDelta);
 
     void AddAnimBlockRef(int ID);
     void RemoveAnimBlockRef(int ID);
@@ -123,13 +128,15 @@ public:
     void                 ReadAnimAssociationDefinitions(void);
     void                 CreateAnimAssocGroups(void);
 
-    void UncompressAnimation(CAnimBlendHierarchy *pHierarchy);
-    void RemoveFromUncompressedCache(CAnimBlendHierarchy *pHierarchy);
-
-    void LoadAnimFile(const char *szFile);
-    void LoadAnimFile(RwStream *pStream, bool b1, const char *sz1);
-    void LoadAnimFiles(void);
-    void RemoveLastAnimFile(void);
+    void  UncompressAnimation(CAnimBlendHierarchy *pHierarchy);
+    void  RemoveFromUncompressedCache(CAnimBlendHierarchy *pHierarchy);
+    void  RemoveFromUncompressedCache(CAnimBlendHierarchySAInterface *pInterface);
+    void  LoadAnimFile(const char *szFile);
+    void  LoadAnimFile(RwStream *pStream, bool b1, const char *sz1);
+    void  LoadAnimFiles(void);
+    void  RemoveLastAnimFile(void);
+    BYTE *AllocateKeyFramesMemory(uint32_t u32BytesToAllocate);
+    void  FreeKeyFramesMemory(void *pKeyFrames);
 
     // Non members
     bool                   HasAnimGroupLoaded(AssocGroupId groupID);
@@ -146,11 +153,37 @@ public:
     CAnimBlock *           GetAnimBlock(CAnimBlockSAInterface *pInterface);
     CAnimBlendHierarchy *  GetAnimBlendHierarchy(CAnimBlendHierarchySAInterface *pInterface);
 
+    StaticAssocIntface_type GetAnimStaticAssociation(CAnimBlendStaticAssociationSAInterface *pInterface);
+
+    // MTA members, but use this strictly for custom animations only
+    std::unique_ptr<CAnimBlendHierarchy> GetCustomAnimBlendHierarchy(CAnimBlendHierarchySAInterface *pInterface);
+    std::unique_ptr<CAnimBlendSequence>  GetCustomAnimBlendSequence(CAnimBlendSequenceSAInterface *pInterface);
+
+    // Warning! These two functions will create a new interface ( dynamic memory memory allocation )
+    std::unique_ptr<CAnimBlendHierarchy> GetCustomAnimBlendHierarchy(void);
+    std::unique_ptr<CAnimBlendSequence>  GetCustomAnimBlendSequence(void);
+
+    void DeleteCustomAnimHierarchyInterface(CAnimBlendHierarchySAInterface *pInterface);
+    void DeleteCustomAnimSequenceInterface(CAnimBlendSequenceSAInterface *pInterface);
+
+    bool           isGateWayAnimationHierarchy(CAnimBlendHierarchySAInterface *pInterface);
+    const SString &GetGateWayBlockName(void) { return m_kGateWayBlockName; };
+    const SString &GetGateWayAnimationName(void) { return m_kGateWayAnimationName; };
+
 private:
     CAnimBlendAssocGroup *             m_pAnimAssocGroups[MAX_ANIM_GROUPS];
     CAnimBlendHierarchy *              m_pAnimations[MAX_ANIMATIONS];
     CAnimBlock *                       m_pAnimBlocks[MAX_ANIM_BLOCKS];
     std::list<CAnimBlendAssociation *> m_Associations;
+
+    // This "gateway" animation will allow us to play custom animations by simply playing this animation
+    // and then in AddAnimation and AddAnimationAndSync hook, we can return our custom animation in the
+    // hook instead of run_wuzi. This will trick GTA SA into thinking that it is playing run_wuzi from
+    // ped block, but in reality, it's playing our custom animation, and Of course, we can return run_wuzi
+    // animation within the hook if we want to play it instead. Why run_wuzi? We can also use another animation,
+    // but I've tested with this one mostly, so let's stick to this.
+    const SString m_kGateWayBlockName = "ped";
+    const SString m_kGateWayAnimationName = "run_wuzi";
 };
 
 #endif

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -98,6 +98,7 @@ struct SCheatSA
 class CGameSA : public CGame
 {
     friend class COffsets;
+    typedef std::unique_ptr<CAnimBlendAssocGroup> AssocGroup_type;
 
 private:
     CWeaponInfo* WeaponInfos[NUM_WeaponInfosTotal];

--- a/Client/mods/deathmatch/StdInc.h
+++ b/Client/mods/deathmatch/StdInc.h
@@ -77,6 +77,7 @@
 #include <CClientStreamSectorRow.h>
 #include <CClientTask.h>
 #include <CClientTXD.h>
+#include <CClientIFP.h>
 #include <CClientWater.h>
 #include <CClientWeapon.h>
 #include <CClientRenderElement.h>
@@ -93,6 +94,9 @@
 #include <CLogger.h>
 #include <CMapEventManager.h>
 #include <CModelNames.h>
+#include <CIFPEngine.h>
+#include <CFileReader.h>
+#include <CIFPAnimations.h>
 #include <CScriptFile.h>
 #include <CWeaponNames.h>
 #include <CVehicleNames.h>

--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -36,6 +36,7 @@ class CClientManager;
 #define IS_COLSHAPE(entity) ((entity)->GetType()==CCLIENTCOLSHAPE)
 #define IS_PROJECTILE(entity) ((entity)->GetType()==CCLIENTPROJECTILE)
 #define IS_GUI(entity) ((entity)->GetType()==CCLIENTGUI)
+#define IS_IFP(entity) ((entity)->GetType()==CCLIENTIFP)
 #define CHECK_CGUI(entity,type) (((CClientGUIElement*)entity)->GetCGUIElement()->GetType()==type)
 
 enum eClientEntityType
@@ -76,6 +77,7 @@ enum eClientEntityType
     CCLIENTRENDERTARGET,
     CCLIENTBROWSER,
     CCLIENTSEARCHLIGHT,
+    CCLIENTIFP,
     CCLIENTUNKNOWN,
 };
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -11,6 +11,9 @@
 
 #include "StdInc.h"
 #include <net/SyncStructures.h>
+#include "game/CAnimBlendAssocGroup.h"
+#include "game/CAnimBlendAssociation.h"
+#include "game/CAnimBlendHierarchy.h"
 
 SString StringZeroPadout(const SString& strInput, uint uiPadoutSize)
 {
@@ -254,8 +257,11 @@ CClientGame::CClientGame(bool bLocalPlay)
     g_pMultiplayer->SetPostWorldProcessHandler(CClientGame::StaticPostWorldProcessHandler);
     g_pMultiplayer->SetPreFxRenderHandler(CClientGame::StaticPreFxRenderHandler);
     g_pMultiplayer->SetPreHudRenderHandler(CClientGame::StaticPreHudRenderHandler);
+    g_pMultiplayer->SetCAnimBlendAssocDestructorHandler(CClientGame::StaticCAnimBlendAssocDestructorHandler);
     g_pMultiplayer->SetAddAnimationHandler(CClientGame::StaticAddAnimationHandler);
-    g_pMultiplayer->SetBlendAnimationHandler(CClientGame::StaticBlendAnimationHandler);
+    g_pMultiplayer->SetAddAnimationAndSyncHandler(CClientGame::StaticAddAnimationAndSyncHandler);
+    g_pMultiplayer->SetAssocGroupCopyAnimationHandler(CClientGame::StaticAssocGroupCopyAnimationHandler);
+    g_pMultiplayer->SetBlendAnimationHierarchyHandler(CClientGame::StaticBlendAnimationHierarchyHandler);
     g_pMultiplayer->SetProcessCollisionHandler(CClientGame::StaticProcessCollisionHandler);
     g_pMultiplayer->SetVehicleCollisionHandler(CClientGame::StaticVehicleCollisionHandler);
     g_pMultiplayer->SetVehicleDamageHandler(CClientGame::StaticVehicleDamageHandler);
@@ -411,8 +417,11 @@ CClientGame::~CClientGame(void)
     g_pMultiplayer->SetPostWorldProcessHandler(NULL);
     g_pMultiplayer->SetPreFxRenderHandler(NULL);
     g_pMultiplayer->SetPreHudRenderHandler(NULL);
+    g_pMultiplayer->SetCAnimBlendAssocDestructorHandler(NULL);
     g_pMultiplayer->SetAddAnimationHandler(NULL);
-    g_pMultiplayer->SetBlendAnimationHandler(NULL);
+    g_pMultiplayer->SetAddAnimationAndSyncHandler(NULL);
+    g_pMultiplayer->SetAssocGroupCopyAnimationHandler(NULL);
+    g_pMultiplayer->SetBlendAnimationHierarchyHandler(NULL);
     g_pMultiplayer->SetProcessCollisionHandler(NULL);
     g_pMultiplayer->SetVehicleCollisionHandler(NULL);
     g_pMultiplayer->SetVehicleDamageHandler(NULL);
@@ -3622,14 +3631,33 @@ bool CClientGame::StaticChokingHandler(unsigned char ucWeaponType)
     return g_pClientGame->ChokingHandler(ucWeaponType);
 }
 
-void CClientGame::StaticAddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID)
+void CClientGame::StaticCAnimBlendAssocDestructorHandler(CAnimBlendAssociationSAInterface* pThis)
 {
-    g_pClientGame->AddAnimationHandler(pClump, animGroup, animID);
+    g_pClientGame->CAnimBlendAssocDestructorHandler(pThis);
 }
 
-void CClientGame::StaticBlendAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta)
+CAnimBlendAssociationSAInterface* CClientGame::StaticAddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID)
 {
-    g_pClientGame->BlendAnimationHandler(pClump, animGroup, animID, fBlendDelta);
+    return g_pClientGame->AddAnimationHandler(pClump, animGroup, animID);
+}
+
+CAnimBlendAssociationSAInterface* CClientGame::StaticAddAnimationAndSyncHandler(RpClump* pClump, CAnimBlendAssociationSAInterface* pAnimAssocToSyncWith,
+                                                                                AssocGroupId animGroup, AnimationId animID)
+{
+    return g_pClientGame->AddAnimationAndSyncHandler(pClump, pAnimAssocToSyncWith, animGroup, animID);
+}
+
+bool CClientGame::StaticAssocGroupCopyAnimationHandler(CAnimBlendStaticAssociationSAInterface* pOutAnimStaticAssoc,
+                                                       CAnimBlendAssociationSAInterface* pAnimAssoc, RpClump* pClump,
+                                                       CAnimBlendAssocGroupSAInterface* pAnimAssocGroup, AnimationId animID)
+{
+    return g_pClientGame->AssocGroupCopyAnimationHandler(pOutAnimStaticAssoc, pAnimAssoc, pClump, pAnimAssocGroup, animID);
+}
+
+bool CClientGame::StaticBlendAnimationHierarchyHandler(CAnimBlendAssociationSAInterface* pAnimAssoc, CAnimBlendHierarchySAInterface** pOutAnimHierarchy,
+                                                       int* pFlags, RpClump* pClump)
+{
+    return g_pClientGame->BlendAnimationHierarchyHandler(pAnimAssoc, pOutAnimHierarchy, pFlags, pClump);
 }
 
 void CClientGame::StaticPreWorldProcessHandler(void)
@@ -3912,14 +3940,98 @@ bool CClientGame::ChokingHandler(unsigned char ucWeaponType)
     return m_pLocalPlayer->CallEvent("onClientPlayerChoke", Arguments, true);
 }
 
-void CClientGame::AddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID)
+void CClientGame::CAnimBlendAssocDestructorHandler(CAnimBlendAssociationSAInterface* pThis)
 {
-    // CClientPed * pPed = m_pPedManager->Get ( pClump, true );
+    // printf("CClientGame::CAnimBlendAssocDestructorHandler called! sAnimID: %d\n", pThis->sAnimID);
+    RemoveAnimationAssociationFromMap(pThis);
 }
 
-void CClientGame::BlendAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta)
+CAnimBlendAssociationSAInterface* CClientGame::AddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID)
 {
-    // CClientPed * pPed = m_pPedManager->Get ( pClump, true );
+    // printf ( "AddAnimationHandler called! pClump, GroupID, AnimID: %p, %d, %d\n", (void*)pClump, animGroup, animID );
+    return nullptr;
+}
+
+CAnimBlendAssociationSAInterface* CClientGame::AddAnimationAndSyncHandler(RpClump* pClump, CAnimBlendAssociationSAInterface* pAnimAssocToSyncWith,
+                                                                          AssocGroupId animGroup, AnimationId animID)
+{
+    // printf ( "AddAnimationAndSyncHandler called! pClump, GroupID, AnimID: %p, %d, %d\n", (void*)pClump, animGroup, animID );
+    return nullptr;
+}
+
+bool CClientGame::AssocGroupCopyAnimationHandler(CAnimBlendStaticAssociationSAInterface* pOutAnimStaticAssocInterface,
+                                                 CAnimBlendAssociationSAInterface* pAnimAssoc, RpClump* pClump,
+                                                 CAnimBlendAssocGroupSAInterface* pAnimAssocGroupInterface, AnimationId animID)
+{
+    bool          isCustomAnimationToPlay = false;
+    CAnimManager* pAnimationManager = g_pGame->GetAnimManager();
+    auto          pAnimAssocGroup = pAnimationManager->GetAnimBlendAssocGroup(pAnimAssocGroupInterface);
+    auto          pOriginalAnimStaticAssoc = pAnimationManager->GetAnimStaticAssociation(pAnimAssocGroup->GetGroupID(), animID);
+    auto          pOriginalAnimHierarchyInterface = pOriginalAnimStaticAssoc->GetAnimHierachyInterface();
+    auto          pOutAnimStaticAssoc = pAnimationManager->GetAnimStaticAssociation(pOutAnimStaticAssocInterface);
+    CClientPed*   pClientPed = GetClientPedByClump(*pClump);
+    if (pClientPed != nullptr)
+    {
+        auto pReplacedAnimation = pClientPed->GetReplacedAnimation(pOriginalAnimHierarchyInterface);
+        if (pReplacedAnimation != nullptr)
+        {
+            std::shared_ptr<CIFPAnimations> pIFPAnimations = pReplacedAnimation->pIFP->GetIFPAnimationsPointer();
+            InsertAnimationAssociationToMap(pAnimAssoc, pIFPAnimations);
+
+            // Play our custom animation instead of default
+            pOutAnimStaticAssoc->Initialize(pClump, pReplacedAnimation->pAnimationHierarchy);
+            isCustomAnimationToPlay = true;
+        }
+    }
+
+    if (!isCustomAnimationToPlay)
+    {
+        // Play default internal animation
+        pOutAnimStaticAssoc->Initialize(pClump, pOriginalAnimHierarchyInterface);
+    }
+
+    CopyStaticAssociationProperties(pOutAnimStaticAssoc, pOriginalAnimStaticAssoc);
+    return isCustomAnimationToPlay;
+}
+
+bool CClientGame::BlendAnimationHierarchyHandler(CAnimBlendAssociationSAInterface* pAnimAssoc, CAnimBlendHierarchySAInterface** pOutAnimHierarchy, int* pFlags,
+                                                 RpClump* pClump)
+{
+    bool          isCustomAnimationToPlay = false;
+    CAnimManager* pAnimationManager = g_pGame->GetAnimManager();
+    CClientPed*   pClientPed = GetClientPedByClump(*pClump);
+    if (pClientPed != nullptr)
+    {
+        if (pClientPed->IsNextAnimationCustom())
+        {
+            std::shared_ptr<CClientIFP> pIFP = pClientPed->GetCustomAnimationIFP();
+            if (pIFP)
+            {
+                const SString& strAnimationName = pClientPed->GetNextAnimationCustomName();
+                auto           pCustomAnimBlendHierarchy = pIFP->GetAnimationHierarchy(strAnimationName);
+                if (pCustomAnimBlendHierarchy != nullptr)
+                {
+                    std::shared_ptr<CIFPAnimations> pIFPAnimations = pIFP->GetIFPAnimationsPointer();
+                    InsertAnimationAssociationToMap(pAnimAssoc, pIFPAnimations);
+
+                    pClientPed->SetCurrentAnimationCustom(true);
+                    pClientPed->SetNextAnimationNormal();
+
+                    if (pIFP->IsUnloading())
+                    {
+                        pClientPed->DereferenceCustomAnimationBlock();
+                    }
+                    *pOutAnimHierarchy = pCustomAnimBlendHierarchy;
+                    isCustomAnimationToPlay = true;
+                    return isCustomAnimationToPlay;
+                }
+            }
+        }
+
+        pClientPed->SetCurrentAnimationCustom(false);
+        pClientPed->SetNextAnimationNormal();
+    }
+    return isCustomAnimationToPlay;
 }
 
 bool CClientGame::ProcessCollisionHandler(CEntitySAInterface* pThisInterface, CEntitySAInterface* pOtherInterface)
@@ -6658,4 +6770,103 @@ void CClientGame::RestreamModel(unsigned short usModel)
         // 'Restream' upgrades after model replacement to propagate visual changes with immediate effect
         if (CClientObjectManager::IsValidModel(usModel) && CVehicleUpgrades::IsUpgrade(usModel))
         m_pManager->GetVehicleManager()->RestreamVehicleUpgrades(usModel);
+}
+
+void CClientGame::CopyStaticAssociationProperties(std::unique_ptr<CAnimBlendStaticAssociation>& pOutAnimStaticAssoc,
+                                                  std::unique_ptr<CAnimBlendStaticAssociation>& pOriginalAnimStaticAssoc)
+{
+    pOutAnimStaticAssoc->SetAnimGroup(pOriginalAnimStaticAssoc->GetAnimGroup());
+    pOutAnimStaticAssoc->SetAnimID(pOriginalAnimStaticAssoc->GetAnimID());
+
+    // Total bones in clump. GTA SA is using 32 bones for peds/players
+    pOutAnimStaticAssoc->SetNumBlendNodes(pOriginalAnimStaticAssoc->GetNumBlendNodes());
+    pOutAnimStaticAssoc->SetFlags(pOriginalAnimStaticAssoc->GetFlags());
+}
+
+void CClientGame::InsertIFPPointerToMap(const unsigned int u32BlockNameHash, const std::shared_ptr<CClientIFP>& pIFP)
+{
+    m_mapOfIfpPointers[u32BlockNameHash] = pIFP;
+}
+
+std::shared_ptr<CClientIFP> CClientGame::GetIFPPointerFromMap(const unsigned int u32BlockNameHash)
+{
+    auto it = m_mapOfIfpPointers.find(u32BlockNameHash);
+    if (it != m_mapOfIfpPointers.end())
+    {
+        return it->second;
+    }
+    return nullptr;
+}
+
+void CClientGame::RemoveIFPPointerFromMap(const unsigned int u32BlockNameHash)
+{
+    m_mapOfIfpPointers.erase(u32BlockNameHash);
+}
+
+void CClientGame::InsertPedPointerToSet(CClientPed* pPed)
+{
+    m_setOfPedPointers.insert(pPed);
+}
+
+void CClientGame::RemovePedPointerFromSet(CClientPed* pPed)
+{
+    m_setOfPedPointers.erase(pPed);
+}
+
+CClientPed* CClientGame::GetClientPedByClump(const RpClump& Clump)
+{
+    for (auto& pPed : m_setOfPedPointers)
+    {
+        CEntity* pEntity = pPed->GetGameEntity();
+        if (pEntity != nullptr)
+        {
+            if (pEntity->GetRpClump() != nullptr)
+            {
+                const RpClump& entityClump = *pEntity->GetRpClump();
+                if (std::addressof(entityClump) == std::addressof(Clump))
+                {
+                    return pPed;
+                }
+            }
+        }
+    }
+    return nullptr;
+}
+
+void CClientGame::OnClientIFPUnload(const std::shared_ptr<CClientIFP>& IFP)
+{
+    IFP->MarkAsUnloading();
+    for (auto& pPed : m_setOfPedPointers)
+    {
+        // Remove IFP animations from replaced animations of peds/players
+        pPed->RestoreAnimations(IFP);
+
+        // Make sure that streamed in pulses or changing model does not accidently
+        // play our custom animation. We can do that by making the custom animation
+        // untriggerable
+        if (pPed->GetCustomAnimationBlockNameHash() == IFP->GetBlockNameHash())
+        {
+            if (pPed->IsCustomAnimationPlaying())
+            {
+                pPed->SetCustomAnimationUntriggerable();
+            }
+
+            // Important! As we are using a shared_ptr, we need to decrement the reference counter
+            // by setting the shared_ptr to nullptr, this will avoid memory leak
+            if (!pPed->IsNextAnimationCustom() && pPed->IsCurrentAnimationCustom())
+            {
+                pPed->DereferenceCustomAnimationBlock();
+            }
+        }
+    }
+}
+
+void CClientGame::InsertAnimationAssociationToMap(CAnimBlendAssociationSAInterface* pAnimAssociation, const std::shared_ptr<CIFPAnimations>& pIFPAnimations)
+{
+    m_mapOfCustomAnimationAssociations[pAnimAssociation] = pIFPAnimations;
+}
+
+void CClientGame::RemoveAnimationAssociationFromMap(CAnimBlendAssociationSAInterface* pAnimAssociation)
+{
+    m_mapOfCustomAnimationAssociations.erase(pAnimAssociation);
 }

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -44,6 +44,7 @@
 #include "CVoiceRecorder.h"
 #include "CSingularFileDownloadManager.h"
 #include "CObjectRespawner.h"
+
 #define HeliKill_List_Clear_Rate 500
 #define MIN_PUSH_ANTISPAM_RATE 1500
 #define INVALID_DOWNLOAD_PRIORITY_GROUP (INT_MIN)
@@ -72,6 +73,7 @@ struct SMiscGameSettings
 class CClientGame
 {
     friend class CPacketHandler;
+    typedef std::map<CAnimBlendAssociationSAInterface*, std::shared_ptr<CIFPAnimations> > AnimAssociations_type;
 
 public:
     enum eStatus
@@ -227,7 +229,7 @@ public:
     bool StartGame(const char* szNick, const char* szPassword, eServerType Type = SERVER_TYPE_NORMAL);
     bool StartLocalGame(eServerType Type, const char* szPassword = NULL);
     void SetupLocalGame(eServerType Type);
-    // bool                                StartGame                       ( void );
+    // bool                                    StartGame                       ( void );
     bool IsLocalGame(void) const { return m_bLocalPlay; }
     bool OnCancelLocalGameClick(CGUIElement* pElement);
 
@@ -484,21 +486,27 @@ private:
     void Event_OnIngame(void);
     void Event_OnIngameAndConnected(void);
 
-    static bool StaticDamageHandler(CPed* pDamagePed, CEventDamage* pEvent);
-    static void StaticDeathHandler(CPed* pKilledPed, unsigned char ucDeathReason, unsigned char ucBodyPart);
-    static void StaticFireHandler(CFire* pFire);
-    static bool StaticBreakTowLinkHandler(CVehicle* pTowedVehicle);
-    static void StaticDrawRadarAreasHandler(void);
-    static void StaticRender3DStuffHandler(void);
-    static void StaticPreRenderSkyHandler(void);
-    static void StaticRenderHeliLightHandler(void);
-    static bool StaticChokingHandler(unsigned char ucWeaponType);
-    static void StaticPreWorldProcessHandler(void);
-    static void StaticPostWorldProcessHandler(void);
-    static void StaticPreFxRenderHandler(void);
-    static void StaticPreHudRenderHandler(void);
-    static void StaticAddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID);
-    static void StaticBlendAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta);
+    static bool                              StaticDamageHandler(CPed* pDamagePed, CEventDamage* pEvent);
+    static void                              StaticDeathHandler(CPed* pKilledPed, unsigned char ucDeathReason, unsigned char ucBodyPart);
+    static void                              StaticFireHandler(CFire* pFire);
+    static bool                              StaticBreakTowLinkHandler(CVehicle* pTowedVehicle);
+    static void                              StaticDrawRadarAreasHandler(void);
+    static void                              StaticRender3DStuffHandler(void);
+    static void                              StaticPreRenderSkyHandler(void);
+    static void                              StaticRenderHeliLightHandler(void);
+    static bool                              StaticChokingHandler(unsigned char ucWeaponType);
+    static void                              StaticPreWorldProcessHandler(void);
+    static void                              StaticPostWorldProcessHandler(void);
+    static void                              StaticPreFxRenderHandler(void);
+    static void                              StaticPreHudRenderHandler(void);
+    static void                              StaticCAnimBlendAssocDestructorHandler(CAnimBlendAssociationSAInterface* pThis);
+    static CAnimBlendAssociationSAInterface* StaticAddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID);
+    static CAnimBlendAssociationSAInterface* StaticAddAnimationAndSyncHandler(RpClump* pClump, CAnimBlendAssociationSAInterface* pAnimAssocToSyncWith,
+                                                                              AssocGroupId animGroup, AnimationId animID);
+    static bool StaticAssocGroupCopyAnimationHandler(CAnimBlendStaticAssociationSAInterface* pOutAnimStaticAssoc, CAnimBlendAssociationSAInterface* pAnimAssoc,
+                                                     RpClump* pClump, CAnimBlendAssocGroupSAInterface* pAnimAssocGroup, AnimationId animID);
+    static bool StaticBlendAnimationHierarchyHandler(CAnimBlendAssociationSAInterface* pAnimAssoc, CAnimBlendHierarchySAInterface** pOutAnimHierarchy,
+                                                     int* pFlags, RpClump* pClump);
     static bool StaticProcessCollisionHandler(CEntitySAInterface* pThisInterface, CEntitySAInterface* pOtherInterface);
     static bool StaticVehicleCollisionHandler(CVehicleSAInterface* pThisInterface, CEntitySAInterface* pOtherInterface, int iModelIndex,
                                               float fDamageImpulseMag, float fCollidingDamageImpulseMag, uint16 usPieceType, CVector vecCollisionPos,
@@ -521,18 +529,24 @@ private:
     static void StaticFxSystemDestructionHandler(void* pFxSAInterface);
     static AnimationId StaticDrivebyAnimationHandler(AnimationId animGroup, AssocGroupId animId);
 
-    bool        DamageHandler(CPed* pDamagePed, CEventDamage* pEvent);
-    void        DeathHandler(CPed* pKilledPed, unsigned char ucDeathReason, unsigned char ucBodyPart);
-    void        FireHandler(CFire* pFire);
-    bool        BreakTowLinkHandler(CVehicle* pTowedVehicle);
-    void        DrawRadarAreasHandler(void);
-    void        Render3DStuffHandler(void);
-    void        PreRenderSkyHandler(void);
-    bool        ChokingHandler(unsigned char ucWeaponType);
-    void        PreWorldProcessHandler(void);
-    void        PostWorldProcessHandler(void);
-    void        AddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID);
-    void        BlendAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta);
+    bool                              DamageHandler(CPed* pDamagePed, CEventDamage* pEvent);
+    void                              DeathHandler(CPed* pKilledPed, unsigned char ucDeathReason, unsigned char ucBodyPart);
+    void                              FireHandler(CFire* pFire);
+    bool                              BreakTowLinkHandler(CVehicle* pTowedVehicle);
+    void                              DrawRadarAreasHandler(void);
+    void                              Render3DStuffHandler(void);
+    void                              PreRenderSkyHandler(void);
+    bool                              ChokingHandler(unsigned char ucWeaponType);
+    void                              PreWorldProcessHandler(void);
+    void                              PostWorldProcessHandler(void);
+    void                              CAnimBlendAssocDestructorHandler(CAnimBlendAssociationSAInterface* pThis);
+    CAnimBlendAssociationSAInterface* AddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID);
+    CAnimBlendAssociationSAInterface* AddAnimationAndSyncHandler(RpClump* pClump, CAnimBlendAssociationSAInterface* pAnimAssocToSyncWith,
+                                                                 AssocGroupId animGroup, AnimationId animID);
+    bool        AssocGroupCopyAnimationHandler(CAnimBlendStaticAssociationSAInterface* pOutAnimStaticAssoc, CAnimBlendAssociationSAInterface* pAnimAssoc,
+                                               RpClump* pClump, CAnimBlendAssocGroupSAInterface* pAnimAssocGroup, AnimationId animID);
+    bool        BlendAnimationHierarchyHandler(CAnimBlendAssociationSAInterface* pAnimAssoc, CAnimBlendHierarchySAInterface** pOutAnimHierarchy, int* pFlags,
+                                               RpClump* pClump);
     bool        ProcessCollisionHandler(CEntitySAInterface* pThisInterface, CEntitySAInterface* pOtherInterface);
     bool        VehicleCollisionHandler(CVehicleSAInterface* pCollidingVehicle, CEntitySAInterface* pCollidedVehicle, int iModelIndex, float fDamageImpulseMag,
                                         float fCollidingDamageImpulseMag, uint16 usPieceType, CVector vecCollisionPos, CVector vecCollisionVelocity);
@@ -587,6 +601,21 @@ public:
     void                           SetFileCacheRoot(void);
     const char*                    GetFileCacheRoot(void) { return m_strFileCacheRoot; }
 
+    void                        CopyStaticAssociationProperties(std::unique_ptr<CAnimBlendStaticAssociation>& pOutAnimStaticAssoc,
+                                                                std::unique_ptr<CAnimBlendStaticAssociation>& pOriginalAnimStaticAssoc);
+    void                        InsertIFPPointerToMap(const unsigned int u32BlockNameHash, const std::shared_ptr<CClientIFP>& pIFP);
+    void                        RemoveIFPPointerFromMap(const unsigned int u32BlockNameHash);
+    std::shared_ptr<CClientIFP> GetIFPPointerFromMap(const unsigned int u32BlockNameHash);
+
+    void        InsertPedPointerToSet(CClientPed* pPed);
+    void        RemovePedPointerFromSet(CClientPed* pPed);
+    CClientPed* GetClientPedByClump(const RpClump& Clump);
+
+    void OnClientIFPUnload(const std::shared_ptr<CClientIFP>& IFP);
+
+    void InsertAnimationAssociationToMap(CAnimBlendAssociationSAInterface* pAnimAssociation, const std::shared_ptr<CIFPAnimations>& pIFPAnimations);
+    void RemoveAnimationAssociationFromMap(CAnimBlendAssociationSAInterface* pAnimAssociation);
+
 private:
     eStatus       m_Status;
     eServerType   m_ServerType;
@@ -628,7 +657,7 @@ private:
     CNetAPI*               m_pNetAPI;
     CNetworkStats*         m_pNetworkStats;
     CSyncDebug*            m_pSyncDebug;
-    // CScreenshot*                        m_pScreenshot;
+    // CScreenshot*                          m_pScreenshot;
     CRadarMap*                    m_pRadarMap;
     CTransferBox*                 m_pTransferBox;
     CResourceManager*             m_pResourceManager;
@@ -799,6 +828,11 @@ private:
     SString           m_strFileCacheRoot;
 
     SharedUtil::CAsyncTaskScheduler* m_pAsyncTaskScheduler;
+
+    // (unsigned int) Key is the hash of custom block name that is supplied to engineLoadIFP
+    std::map<unsigned int, std::shared_ptr<CClientIFP> > m_mapOfIfpPointers;
+    std::set<CClientPed*>                                m_setOfPedPointers;
+    AnimAssociations_type                                m_mapOfCustomAnimationAssociations;
 };
 
 extern CClientGame* g_pClientGame;

--- a/Client/mods/deathmatch/logic/CClientIFP.cpp
+++ b/Client/mods/deathmatch/logic/CClientIFP.cpp
@@ -1,0 +1,1096 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClientIFP.cpp
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include <StdInc.h>
+#include "game/CAnimBlendSequence.h"
+#include "game/CAnimBlendHierarchy.h"
+
+CClientIFP::CClientIFP(class CClientManager* pManager, ElementID ID) : CClientEntity(ID)
+{
+    // Init
+    m_pManager = pManager;
+    SetTypeName("IFP");
+    m_pIFPAnimations = std::make_shared<CIFPAnimations>();
+    m_pAnimManager = g_pGame->GetAnimManager();
+    m_bVersion1 = false;
+    m_bUnloading = false;
+    m_u32Hashkey = 0;
+}
+
+bool CClientIFP::LoadIFP(const SString& strFilePath, const SString& strBlockName)
+{
+    m_strBlockName = strBlockName;
+    m_pVecAnimations = &m_pIFPAnimations->vecAnimations;
+
+    if (LoadIFPFile(strFilePath))
+    {
+        m_u32Hashkey = HashString(strBlockName.ToLower());
+        return true;
+    }
+    return false;
+}
+
+bool CClientIFP::LoadIFPFile(const SString& strFilePath)
+{
+    if (LoadFileToMemory(strFilePath))
+    {
+        if (ReadIFPByVersion())
+        {
+            // We are freeing the file reader memory because we don't need to read it anymore.
+            // This function does not unload IFP, to unload ifp, use destroyElement from Lua
+            FreeFileReaderMemory();
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CClientIFP::ReadIFPByVersion(void)
+{
+    char Version[4];
+    ReadBytes(Version, sizeof(Version));
+
+    bool bAnp3 = strncmp(Version, "ANP3", sizeof(Version)) == 0;
+    bool bAnp2 = strncmp(Version, "ANP2", sizeof(Version)) == 0;
+    bool bAnpk = strncmp(Version, "ANPK", sizeof(Version)) == 0;
+
+    if (bAnp2 || bAnp3)
+    {
+        ReadIFPVersion2(bAnp3);
+        return true;
+    }
+    else if (bAnpk)
+    {
+        m_bVersion1 = true;
+        ReadIFPVersion1();
+        return true;
+    }
+    return false;
+}
+
+void CClientIFP::ReadIFPVersion1(void)
+{
+    SInfo Info;
+    ReadHeaderVersion1(Info);
+
+    m_pVecAnimations->resize(Info.Entries);
+    for (auto& Animation : m_pIFPAnimations->vecAnimations)
+    {
+        ReadAnimationNameVersion1(Animation);
+
+        SDgan Dgan;
+        ReadDgan(Dgan);
+
+        Animation.pHierarchy = m_pAnimManager->GetCustomAnimBlendHierarchy();
+        InitializeAnimationHierarchy(Animation.pHierarchy, Animation.Name, Dgan.Info.Entries);
+        Animation.pSequencesMemory = AllocateSequencesMemory(Animation.pHierarchy);
+        Animation.pHierarchy->SetSequences(reinterpret_cast<CAnimBlendSequenceSAInterface*>(Animation.pSequencesMemory + 4));
+
+        *(DWORD*)Animation.pSequencesMemory = ReadSequencesWithDummies(Animation.pHierarchy);
+        PreProcessAnimationHierarchy(Animation.pHierarchy);
+    }
+}
+
+void CClientIFP::ReadIFPVersion2(bool bAnp3)
+{
+    SIFPHeaderV2 Header;
+    ReadBuffer<SIFPHeaderV2>(&Header);
+
+    m_pVecAnimations->resize(Header.TotalAnimations);
+    for (auto& Animation : m_pIFPAnimations->vecAnimations)
+    {
+        SAnimationHeaderV2 AnimationNode;
+        ReadAnimationHeaderVersion2(AnimationNode, bAnp3);
+
+        Animation.Name = AnimationNode.Name;
+        Animation.uiNameHash = HashString(Animation.Name.ToLower());
+        Animation.pHierarchy = m_pAnimManager->GetCustomAnimBlendHierarchy();
+        InitializeAnimationHierarchy(Animation.pHierarchy, AnimationNode.Name, AnimationNode.TotalObjects);
+
+        Animation.pSequencesMemory = AllocateSequencesMemory(Animation.pHierarchy);
+        Animation.pHierarchy->SetSequences(reinterpret_cast<CAnimBlendSequenceSAInterface*>(Animation.pSequencesMemory + 4));
+
+        *(DWORD*)Animation.pSequencesMemory = ReadSequencesWithDummies(Animation.pHierarchy);
+        PreProcessAnimationHierarchy(Animation.pHierarchy);
+    }
+}
+
+WORD CClientIFP::ReadSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy)
+{
+    SequenceMapType MapOfSequences;
+    WORD            wUnknownSequences = ReadSequences(pAnimationHierarchy, MapOfSequences);
+
+    MoveSequencesWithDummies(pAnimationHierarchy, MapOfSequences);
+    WORD cSequences = m_kcIFPSequences + wUnknownSequences;
+
+    // As we need support for all 32 bones, we must change the total sequences count
+    pAnimationHierarchy->SetNumSequences(cSequences);
+    return cSequences;
+}
+
+WORD CClientIFP::ReadSequences(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences)
+{
+    if (m_bVersion1)
+    {
+        return ReadSequencesVersion1(pAnimationHierarchy, MapOfSequences);
+    }
+    return ReadSequencesVersion2(pAnimationHierarchy, MapOfSequences);
+}
+
+WORD CClientIFP::ReadSequencesVersion1(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences)
+{
+    WORD wUnknownSequences = 0;
+    for (size_t SequenceIndex = 0; SequenceIndex < pAnimationHierarchy->GetNumSequences(); SequenceIndex++)
+    {
+        SAnim        Anim;
+        std::int32_t iBoneID = ReadSequenceVersion1(Anim);
+        if (Anim.Frames == 0)
+        {
+            continue;
+        }
+
+        std::unique_ptr<CAnimBlendSequence> pAnimationSequence;
+        bool                                bUnknownSequence = iBoneID == eBoneType::UNKNOWN;
+        if (bUnknownSequence)
+        {
+            size_t UnkownSequenceIndex = m_kcIFPSequences + wUnknownSequences;
+            auto   pAnimationSequenceInterface = pAnimationHierarchy->GetSequence(UnkownSequenceIndex);
+            pAnimationSequence = m_pAnimManager->GetCustomAnimBlendSequence(pAnimationSequenceInterface);
+            wUnknownSequences++;
+        }
+        else
+        {
+            pAnimationSequence = m_pAnimManager->GetCustomAnimBlendSequence();
+        }
+        InitializeAnimationSequence(pAnimationSequence, Anim.Name, iBoneID);
+
+        eFrameType iFrameType = ReadKfrm();
+        if ((ReadSequenceKeyFrames(pAnimationSequence, iFrameType, Anim.Frames)) && (!bUnknownSequence))
+        {
+            MapOfSequences[iBoneID] = std::move(pAnimationSequence);
+        }
+    }
+    return wUnknownSequences;
+}
+
+WORD CClientIFP::ReadSequencesVersion2(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences)
+{
+    WORD wUnknownSequences = 0;
+    for (size_t SequenceIndex = 0; SequenceIndex < pAnimationHierarchy->GetNumSequences(); SequenceIndex++)
+    {
+        SSequenceHeaderV2 ObjectNode;
+        ReadSequenceVersion2(ObjectNode);
+
+        bool bUnknownSequence = ObjectNode.BoneID == eBoneType::UNKNOWN;
+
+        std::unique_ptr<CAnimBlendSequence> pAnimationSequence;
+        if (bUnknownSequence)
+        {
+            size_t UnkownSequenceIndex = m_kcIFPSequences + wUnknownSequences;
+            auto   pAnimationSequenceInterface = pAnimationHierarchy->GetSequence(UnkownSequenceIndex);
+            pAnimationSequence = m_pAnimManager->GetCustomAnimBlendSequence(pAnimationSequenceInterface);
+            wUnknownSequences++;
+        }
+        else
+        {
+            pAnimationSequence = m_pAnimManager->GetCustomAnimBlendSequence();
+        }
+        InitializeAnimationSequence(pAnimationSequence, ObjectNode.Name, ObjectNode.BoneID);
+
+        eFrameType iFrameType = static_cast<eFrameType>(ObjectNode.FrameType);
+        if ((ReadSequenceKeyFrames(pAnimationSequence, iFrameType, ObjectNode.TotalFrames)) && (!bUnknownSequence))
+        {
+            MapOfSequences[ObjectNode.BoneID] = std::move(pAnimationSequence);
+        }
+    }
+    return wUnknownSequences;
+}
+
+std::int32_t CClientIFP::ReadSequenceVersion1(SAnim& Anim)
+{
+    SCpan Cpan;
+    ReadBuffer<SCpan>(&Cpan);
+    RoundSize(Cpan.Base.Size);
+    ReadBytes(&Anim, sizeof(SBase));
+    RoundSize(Anim.Base.Size);
+    ReadBytes(&Anim.Name, Anim.Base.Size);
+
+    std::int32_t iBoneID = eBoneType::UNKNOWN;
+    if (Anim.Base.Size == 0x2C)
+    {
+        iBoneID = Anim.Next;
+    }
+
+    SString strBoneName = ConvertStringToKey(Anim.Name);
+    iBoneID = GetBoneIDFromName(strBoneName);
+
+    SString strCorrectBoneName = GetCorrectBoneNameFromName(strBoneName);
+    strncpy(Anim.Name, strCorrectBoneName, strCorrectBoneName.size() + 1);
+    return iBoneID;
+}
+
+void CClientIFP::ReadSequenceVersion2(SSequenceHeaderV2& ObjectNode)
+{
+    ReadBuffer<SSequenceHeaderV2>(&ObjectNode);
+    SString strBoneName = ConvertStringToKey(ObjectNode.Name);
+    SString strCorrectBoneName;
+    if (ObjectNode.BoneID == eBoneType::UNKNOWN)
+    {
+        ObjectNode.BoneID = GetBoneIDFromName(strBoneName);
+        strCorrectBoneName = GetCorrectBoneNameFromName(strBoneName);
+    }
+    else
+    {
+        strCorrectBoneName = GetCorrectBoneNameFromID(ObjectNode.BoneID);
+        if (strCorrectBoneName.size() == 0)
+        {
+            strCorrectBoneName = GetCorrectBoneNameFromName(strBoneName);
+        }
+    }
+
+    strncpy(ObjectNode.Name, strCorrectBoneName, strCorrectBoneName.size() + 1);
+}
+
+bool CClientIFP::ReadSequenceKeyFrames(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, eFrameType iFrameType, const std::int32_t& cFrames)
+{
+    size_t iCompressedFrameSize = GetSizeOfCompressedFrame(iFrameType);
+    if (iCompressedFrameSize)
+    {
+        BYTE* pKeyFrames = m_pAnimManager->AllocateKeyFramesMemory(iCompressedFrameSize * cFrames);
+        pAnimationSequence->SetKeyFrames(cFrames, IsKeyFramesTypeRoot(iFrameType), m_kbAllKeyFramesCompressed, pKeyFrames);
+        ReadKeyFramesAsCompressed(pAnimationSequence, iFrameType, cFrames);
+        return true;
+    }
+    return false;
+}
+
+void CClientIFP::ReadHeaderVersion1(SInfo& Info)
+{
+    std::uint32_t OffsetEOF;
+    ReadBuffer<std::uint32_t>(&OffsetEOF);
+    RoundSize(OffsetEOF);
+    ReadBytes(&Info, sizeof(SBase));
+    RoundSize(Info.Base.Size);
+    ReadBytes(&Info.Entries, Info.Base.Size);
+}
+
+void CClientIFP::ReadAnimationNameVersion1(SAnimation& IfpAnimation)
+{
+    SName Name;
+    ReadBuffer<SName>(&Name);
+    RoundSize(Name.Base.Size);
+
+    char szAnimationName[24];
+    ReadStringNullTerminated(szAnimationName, Name.Base.Size);
+    IfpAnimation.Name = szAnimationName;
+    IfpAnimation.uiNameHash = HashString(IfpAnimation.Name.ToLower());
+}
+
+void CClientIFP::ReadDgan(SDgan& Dgan)
+{
+    ReadBytes(&Dgan, sizeof(SBase) * 2);
+    RoundSize(Dgan.Base.Size);
+    RoundSize(Dgan.Info.Base.Size);
+    ReadBytes(&Dgan.Info.Entries, Dgan.Info.Base.Size);
+}
+
+CClientIFP::eFrameType CClientIFP::ReadKfrm(void)
+{
+    SKfrm Kfrm;
+    ReadBuffer<SKfrm>(&Kfrm);
+    return GetFrameTypeFromFourCC(Kfrm.Base.FourCC);
+}
+
+void CClientIFP::ReadAnimationHeaderVersion2(SAnimationHeaderV2& AnimationNode, bool bAnp3)
+{
+    ReadStringNullTerminated((char*)&AnimationNode.Name, sizeof(SAnimationHeaderV2::Name));
+    ReadBuffer<std::int32_t>(&AnimationNode.TotalObjects);
+    if (bAnp3)
+    {
+        ReadBuffer<std::int32_t>(&AnimationNode.FrameSize);
+        ReadBuffer<std::int32_t>(&AnimationNode.isCompressed);
+    }
+}
+
+void CClientIFP::ReadKeyFramesAsCompressed(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, eFrameType iFrameType, const std::int32_t& cFrames)
+{
+    switch (iFrameType)
+    {
+        case eFrameType::KRTS:
+        {
+            ReadKrtsFramesAsCompressed(pAnimationSequence, cFrames);
+            break;
+        }
+        case eFrameType::KRT0:
+        {
+            ReadKrt0FramesAsCompressed(pAnimationSequence, cFrames);
+            break;
+        }
+        case eFrameType::KR00:
+        {
+            ReadKr00FramesAsCompressed(pAnimationSequence, cFrames);
+            break;
+        }
+        case eFrameType::KR00_COMPRESSED:
+        {
+            ReadCompressedFrames<SCompressed_KR00>(pAnimationSequence, cFrames);
+            break;
+        }
+        case eFrameType::KRT0_COMPRESSED:
+        {
+            ReadCompressedFrames<SCompressed_KRT0>(pAnimationSequence, cFrames);
+            break;
+        }
+    }
+}
+
+void CClientIFP::ReadKrtsFramesAsCompressed(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const std::int32_t& cFrames)
+{
+    for (std::int32_t FrameIndex = 0; FrameIndex < cFrames; FrameIndex++)
+    {
+        SCompressed_KRT0* CompressedKrt0 = static_cast<SCompressed_KRT0*>(pAnimationSequence->GetKeyFrame(FrameIndex, sizeof(SCompressed_KRT0)));
+        SKrts             Krts;
+        ReadBuffer<SKrts>(&Krts);
+
+        CompressedKrt0->Rotation.X = static_cast<int16_t>(((-Krts.Rotation.X) * 4096.0f));
+        CompressedKrt0->Rotation.Y = static_cast<int16_t>(((-Krts.Rotation.Y) * 4096.0f));
+        CompressedKrt0->Rotation.Z = static_cast<int16_t>(((-Krts.Rotation.Z) * 4096.0f));
+        CompressedKrt0->Rotation.W = static_cast<int16_t>((Krts.Rotation.W * 4096.0f));
+        CompressedKrt0->Time = static_cast<int16_t>((Krts.Time * 60.0f + 0.5f));
+        CompressedKrt0->Translation.X = static_cast<int16_t>((Krts.Translation.X * 1024.0f));
+        CompressedKrt0->Translation.Y = static_cast<int16_t>((Krts.Translation.Y * 1024.0f));
+        CompressedKrt0->Translation.Z = static_cast<int16_t>((Krts.Translation.Z * 1024.0f));
+    }
+}
+
+void CClientIFP::ReadKrt0FramesAsCompressed(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const std::int32_t& cFrames)
+{
+    for (std::int32_t FrameIndex = 0; FrameIndex < cFrames; FrameIndex++)
+    {
+        SCompressed_KRT0* CompressedKrt0 = static_cast<SCompressed_KRT0*>(pAnimationSequence->GetKeyFrame(FrameIndex, sizeof(SCompressed_KRT0)));
+        SKrt0             Krt0;
+        ReadBuffer<SKrt0>(&Krt0);
+
+        CompressedKrt0->Rotation.X = static_cast<int16_t>(((-Krt0.Rotation.X) * 4096.0f));
+        CompressedKrt0->Rotation.Y = static_cast<int16_t>(((-Krt0.Rotation.Y) * 4096.0f));
+        CompressedKrt0->Rotation.Z = static_cast<int16_t>(((-Krt0.Rotation.Z) * 4096.0f));
+        CompressedKrt0->Rotation.W = static_cast<int16_t>((Krt0.Rotation.W * 4096.0f));
+        CompressedKrt0->Time = static_cast<int16_t>((Krt0.Time * 60.0f + 0.5f));
+        CompressedKrt0->Translation.X = static_cast<int16_t>((Krt0.Translation.X * 1024.0f));
+        CompressedKrt0->Translation.Y = static_cast<int16_t>((Krt0.Translation.Y * 1024.0f));
+        CompressedKrt0->Translation.Z = static_cast<int16_t>((Krt0.Translation.Z * 1024.0f));
+    }
+}
+
+void CClientIFP::ReadKr00FramesAsCompressed(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const std::int32_t& cFrames)
+{
+    for (std::int32_t FrameIndex = 0; FrameIndex < cFrames; FrameIndex++)
+    {
+        SCompressed_KR00* CompressedKr00 = static_cast<SCompressed_KR00*>(pAnimationSequence->GetKeyFrame(FrameIndex, sizeof(SCompressed_KR00)));
+        SKr00             Kr00;
+        ReadBuffer<SKr00>(&Kr00);
+
+        CompressedKr00->Rotation.X = static_cast<int16_t>(((-Kr00.Rotation.X) * 4096.0f));
+        CompressedKr00->Rotation.Y = static_cast<int16_t>(((-Kr00.Rotation.Y) * 4096.0f));
+        CompressedKr00->Rotation.Z = static_cast<int16_t>(((-Kr00.Rotation.Z) * 4096.0f));
+        CompressedKr00->Rotation.W = static_cast<int16_t>((Kr00.Rotation.W * 4096.0f));
+        CompressedKr00->Time = static_cast<int16_t>((Kr00.Time * 60.0f + 0.5f));
+    }
+}
+
+size_t CClientIFP::GetSizeOfCompressedFrame(eFrameType iFrameType)
+{
+    switch (iFrameType)
+    {
+        case eFrameType::KRTS:
+        {
+            return sizeof(SCompressed_KRT0);
+        }
+        case eFrameType::KRT0:
+        {
+            return sizeof(SCompressed_KRT0);
+        }
+        case eFrameType::KR00:
+        {
+            return sizeof(SCompressed_KR00);
+        }
+        case eFrameType::KR00_COMPRESSED:
+        {
+            return sizeof(SCompressed_KR00);
+        }
+        case eFrameType::KRT0_COMPRESSED:
+        {
+            return sizeof(SCompressed_KRT0);
+        }
+    }
+    return 0;
+}
+
+void CClientIFP::InitializeAnimationHierarchy(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, const SString& strAnimationName,
+                                              const std::int32_t& iSequences)
+{
+    pAnimationHierarchy->Initialize();
+    pAnimationHierarchy->SetName(strAnimationName);
+    pAnimationHierarchy->SetNumSequences(iSequences);
+    pAnimationHierarchy->SetAnimationBlockID(0);
+    pAnimationHierarchy->SetRunningCompressed(m_kbAllKeyFramesCompressed);
+}
+
+void CClientIFP::InitializeAnimationSequence(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const SString& strName, const std::int32_t& iBoneID)
+{
+    pAnimationSequence->Initialize();
+    pAnimationSequence->SetName(strName);
+    pAnimationSequence->SetBoneTag(iBoneID);
+}
+
+void CClientIFP::PreProcessAnimationHierarchy(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy)
+{
+    if (!pAnimationHierarchy->isRunningCompressed())
+    {
+        pAnimationHierarchy->RemoveQuaternionFlips();
+        pAnimationHierarchy->CalculateTotalTime();
+    }
+}
+
+void CClientIFP::MoveSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& mapOfSequences)
+{
+    for (size_t SequenceIndex = 0; SequenceIndex < m_kcIFPSequences; SequenceIndex++)
+    {
+        SString BoneName = m_karrstrBoneNames[SequenceIndex];
+        DWORD   BoneID = m_karruBoneIds[SequenceIndex];
+
+        auto pAnimationSequenceInterface = pAnimationHierarchy->GetSequence(SequenceIndex);
+        auto pAnimationSequence = m_pAnimManager->GetCustomAnimBlendSequence(pAnimationSequenceInterface);
+        auto it = mapOfSequences.find(BoneID);
+        if (it != mapOfSequences.end())
+        {
+            auto pMapAnimSequenceInterface = it->second->GetInterface();
+            pAnimationSequence->CopySequenceProperties(pMapAnimSequenceInterface);
+            // Delete the interface because we are moving, not copying
+            m_pAnimManager->DeleteCustomAnimSequenceInterface(pMapAnimSequenceInterface);
+        }
+        else
+        {
+            InsertAnimationDummySequence(pAnimationSequence, BoneName, BoneID);
+        }
+    }
+}
+
+BYTE* CClientIFP::AllocateSequencesMemory(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy)
+{
+    const WORD cMaxSequences = m_kcIFPSequences + pAnimationHierarchy->GetNumSequences();
+    return static_cast<BYTE*>(operator new(12 * cMaxSequences + 4));
+}
+
+CClientIFP::eFrameType CClientIFP::GetFrameTypeFromFourCC(const char* szFourCC)
+{
+    if (strncmp(szFourCC, "KRTS", 4) == 0)
+    {
+        return eFrameType::KRTS;
+    }
+    else if (strncmp(szFourCC, "KRT0", 4) == 0)
+    {
+        return eFrameType::KRT0;
+    }
+    else if (strncmp(szFourCC, "KR00", 4) == 0)
+    {
+        return eFrameType::KR00;
+    }
+
+    return eFrameType::UNKNOWN_FRAME;
+}
+
+void CClientIFP::InsertAnimationDummySequence(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const SString& BoneName, const DWORD& dwBoneID)
+{
+    InitializeAnimationSequence(pAnimationSequence, BoneName, dwBoneID);
+
+    bool bRootBone = dwBoneID == eBoneType::NORMAL;
+    bool bHasTranslationValues = false;
+
+    // We only need 1 dummy key frame to make the animation work
+    const size_t cKeyFrames = 1;
+    // KR00 is child key frame and KRT0 is Root key frame
+    size_t FrameSize = sizeof(SCompressed_KR00);
+
+    if (bRootBone)
+    {
+        // This key frame will have translation values.
+        FrameSize = sizeof(SCompressed_KRT0);
+        bHasTranslationValues = true;
+    }
+
+    const size_t FramesDataSizeInBytes = FrameSize * cKeyFrames;
+    BYTE*        pKeyFrames = m_pAnimManager->AllocateKeyFramesMemory(FramesDataSizeInBytes);
+    pAnimationSequence->SetKeyFrames(cKeyFrames, bHasTranslationValues, m_kbAllKeyFramesCompressed, pKeyFrames);
+    CopyDummyKeyFrameByBoneID(pKeyFrames, dwBoneID);
+}
+
+void CClientIFP::CopyDummyKeyFrameByBoneID(BYTE* pKeyFrames, DWORD dwBoneID)
+{
+    switch (dwBoneID)
+    {
+        case eBoneType::NORMAL:            // Normal or Root, both are same
+        {
+            // This is a root frame. It contains translation as well, but it's compressed just like quaternion
+            BYTE FrameData[16] = {0x1F, 0x00, 0x00, 0x00, 0x53, 0x0B, 0x4D, 0x0B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x18, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::PELVIS:
+        {
+            BYTE FrameData[10] = {0xB0, 0xF7, 0xB0, 0xF7, 0x55, 0xF8, 0xAB, 0x07, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::SPINE:
+        {
+            BYTE FrameData[10] = {0x0E, 0x00, 0x15, 0x00, 0xBE, 0xFF, 0xFF, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::SPINE1:
+        {
+            BYTE FrameData[10] = {0x29, 0x00, 0xD9, 0x00, 0xB5, 0x00, 0xF5, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::NECK:
+        {
+            BYTE FrameData[10] = {0x86, 0xFF, 0xB6, 0xFF, 0x12, 0x02, 0xDA, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::HEAD:
+        {
+            BYTE FrameData[10] = {0xFA, 0x00, 0x0C, 0x01, 0x96, 0xFE, 0xDF, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::JAW:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x2B, 0x0D, 0x16, 0x09, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_BROW:
+        {
+            BYTE FrameData[10] = {0xC4, 0x00, 0xFF, 0xFE, 0x47, 0x09, 0xF8, 0x0C, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_BROW:
+        {
+            BYTE FrameData[10] = {0xA2, 0xFF, 0xF8, 0x00, 0x4F, 0x09, 0xF8, 0x0C, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_CLAVICLE:
+        {
+            BYTE FrameData[10] = {0x7E, 0xF5, 0x82, 0x02, 0x37, 0xF4, 0x6A, 0xFF, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_UPPER_ARM:
+        {
+            BYTE FrameData[10] = {0xA8, 0x02, 0x6D, 0x09, 0x1F, 0xFD, 0x51, 0x0C, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_FORE_ARM:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x3A, 0xFE, 0xE6, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_HAND:
+        {
+            BYTE FrameData[10] = {0x9D, 0xF5, 0xBA, 0xFF, 0xEA, 0xFF, 0x29, 0x0C, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_FINGER:
+        {
+            BYTE FrameData[10] = {0xFF, 0xFF, 0x00, 0x00, 0xD8, 0x04, 0x3F, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_FINGER_01:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x54, 0x06, 0xB1, 0x0E, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_CLAVICLE:
+        {
+            BYTE FrameData[10] = {0x0B, 0x0A, 0x3D, 0xFE, 0xBB, 0xF3, 0xCF, 0xFE, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_UPPER_ARM:
+        {
+            BYTE FrameData[10] = {0xF7, 0xFD, 0xED, 0xF6, 0xEB, 0xFD, 0xD9, 0x0C, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_FORE_ARM:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x42, 0xFF, 0xFB, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_HAND:
+        {
+            BYTE FrameData[10] = {0xE9, 0x0B, 0x94, 0x00, 0x25, 0x02, 0x72, 0x0A, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_FINGER:
+        {
+            BYTE FrameData[10] = {0x37, 0x00, 0xCB, 0xFF, 0x10, 0x09, 0x2E, 0x0D, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_FINGER_01:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x60, 0x06, 0xAC, 0x0E, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_BREAST:
+        {
+            BYTE FrameData[10] = {0xC5, 0x01, 0x2B, 0x01, 0x53, 0x0A, 0x09, 0x0C, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_BREAST:
+        {
+            BYTE FrameData[10] = {0x2F, 0xFF, 0xA5, 0xFF, 0xBA, 0x0A, 0xD6, 0x0B, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::BELLY:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x20, 0x0B, 0x7F, 0x0B, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_THIGH:
+        {
+            BYTE FrameData[10] = {0x23, 0xFE, 0x44, 0xF0, 0x19, 0xFE, 0x25, 0x01, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_CALF:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x1E, 0xFC, 0x85, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_FOOT:
+        {
+            BYTE FrameData[10] = {0xBB, 0xFE, 0x3E, 0xFF, 0xD2, 0x01, 0xD3, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::L_TOE_0:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x01, 0x00, 0x8D, 0x0B, 0x12, 0x0B, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_THIGH:
+        {
+            BYTE FrameData[10] = {0x0F, 0xFF, 0x19, 0xF0, 0x44, 0x01, 0xBB, 0x00, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_CALF:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x64, 0xFD, 0xC9, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_FOOT:
+        {
+            BYTE FrameData[10] = {0x11, 0x01, 0x9F, 0xFF, 0x9E, 0x01, 0xE0, 0x0F, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        case eBoneType::R_TOE_0:
+        {
+            BYTE FrameData[10] = {0x00, 0x00, 0x00, 0x00, 0x50, 0x0B, 0x4F, 0x0B, 0x00, 0x00};
+            memcpy(pKeyFrames, FrameData, sizeof(FrameData));
+            break;
+        }
+        default:
+        {
+        }
+    }
+}
+
+SString CClientIFP::ConvertStringToKey(const SString& strBoneName)
+{
+    SString ConvertedString = strBoneName.ToLower();
+    // Remove white spaces
+    ConvertedString.erase(std::remove(ConvertedString.begin(), ConvertedString.end(), ' '), ConvertedString.end());
+    return ConvertedString;
+}
+
+constexpr void CClientIFP::RoundSize(std::uint32_t& u32Size)
+{
+    if (u32Size & 3)
+    {
+        u32Size += 4 - (u32Size & 3);
+    }
+}
+
+constexpr bool CClientIFP::IsKeyFramesTypeRoot(eFrameType iFrameType)
+{
+    switch (iFrameType)
+    {
+        case eFrameType::KR00:
+        {
+            return false;
+        }
+        case eFrameType::KR00_COMPRESSED:
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::int32_t CClientIFP::GetBoneIDFromName(const SString& strBoneName)
+{
+    if (strBoneName == "root")
+        return eBoneType::NORMAL;
+    if (strBoneName == "normal")
+        return eBoneType::NORMAL;
+
+    if (strBoneName == "pelvis")
+        return eBoneType::PELVIS;
+    if (strBoneName == "spine")
+        return eBoneType::SPINE;
+    if (strBoneName == "spine1")
+        return eBoneType::SPINE1;
+    if (strBoneName == "neck")
+        return eBoneType::NECK;
+    if (strBoneName == "head")
+        return eBoneType::HEAD;
+    if (strBoneName == "jaw")
+        return eBoneType::JAW;
+    if (strBoneName == "lbrow")
+        return eBoneType::L_BROW;
+    if (strBoneName == "rbrow")
+        return eBoneType::R_BROW;
+    if (strBoneName == "bip01lclavicle")
+        return eBoneType::L_CLAVICLE;
+    if (strBoneName == "lupperarm")
+        return eBoneType::L_UPPER_ARM;
+    if (strBoneName == "lforearm")
+        return eBoneType::L_FORE_ARM;
+    if (strBoneName == "lhand")
+        return eBoneType::L_HAND;
+
+    if (strBoneName == "lfingers")
+        return eBoneType::L_FINGER;
+    if (strBoneName == "lfinger")
+        return eBoneType::L_FINGER;
+
+    if (strBoneName == "lfinger01")
+        return eBoneType::L_FINGER_01;
+    if (strBoneName == "bip01rclavicle")
+        return eBoneType::R_CLAVICLE;
+    if (strBoneName == "rupperarm")
+        return eBoneType::R_UPPER_ARM;
+    if (strBoneName == "rforearm")
+        return eBoneType::R_FORE_ARM;
+    if (strBoneName == "rhand")
+        return eBoneType::R_HAND;
+
+    if (strBoneName == "rfingers")
+        return eBoneType::R_FINGER;
+    if (strBoneName == "rfinger")
+        return eBoneType::R_FINGER;
+
+    if (strBoneName == "rfinger01")
+        return eBoneType::R_FINGER_01;
+    if (strBoneName == "lbreast")
+        return eBoneType::L_BREAST;
+    if (strBoneName == "rbreast")
+        return eBoneType::R_BREAST;
+    if (strBoneName == "belly")
+        return eBoneType::BELLY;
+    if (strBoneName == "lthigh")
+        return eBoneType::L_THIGH;
+    if (strBoneName == "lcalf")
+        return eBoneType::L_CALF;
+    if (strBoneName == "lfoot")
+        return eBoneType::L_FOOT;
+    if (strBoneName == "ltoe0")
+        return eBoneType::L_TOE_0;
+    if (strBoneName == "rthigh")
+        return eBoneType::R_THIGH;
+    if (strBoneName == "rcalf")
+        return eBoneType::R_CALF;
+    if (strBoneName == "rfoot")
+        return eBoneType::R_FOOT;
+    if (strBoneName == "rtoe0")
+        return eBoneType::R_TOE_0;
+
+    // for GTA 3
+    if (strBoneName == "player")
+        return eBoneType::NORMAL;
+
+    if (strBoneName == "swaist")
+        return eBoneType::PELVIS;
+    if (strBoneName == "smid")
+        return eBoneType::SPINE;
+    if (strBoneName == "storso")
+        return eBoneType::SPINE1;
+    if (strBoneName == "shead")
+        return eBoneType::HEAD;
+
+    if (strBoneName == "supperarml")
+        return eBoneType::L_UPPER_ARM;
+    if (strBoneName == "slowerarml")
+        return eBoneType::L_FORE_ARM;
+    if (strBoneName == "supperarmr")
+        return eBoneType::R_UPPER_ARM;
+    if (strBoneName == "slowerarmr")
+        return eBoneType::R_FORE_ARM;
+
+    if (strBoneName == "srhand")
+        return eBoneType::R_HAND;
+    if (strBoneName == "slhand")
+        return eBoneType::L_HAND;
+
+    if (strBoneName == "supperlegr")
+        return eBoneType::R_THIGH;
+    if (strBoneName == "slowerlegr")
+        return eBoneType::R_CALF;
+    if (strBoneName == "sfootr")
+        return eBoneType::R_FOOT;
+
+    if (strBoneName == "supperlegl")
+        return eBoneType::L_THIGH;
+    if (strBoneName == "slowerlegl")
+        return eBoneType::L_CALF;
+    if (strBoneName == "sfootl")
+        return eBoneType::L_FOOT;
+
+    return eBoneType::UNKNOWN;
+}
+
+SString CClientIFP::GetCorrectBoneNameFromID(const std::int32_t& iBoneID)
+{
+    if (iBoneID == eBoneType::NORMAL)
+        return "Normal";
+
+    if (iBoneID == eBoneType::PELVIS)
+        return "Pelvis";
+    if (iBoneID == eBoneType::SPINE)
+        return "Spine";
+    if (iBoneID == eBoneType::SPINE1)
+        return "Spine1";
+    if (iBoneID == eBoneType::NECK)
+        return "Neck";
+    if (iBoneID == eBoneType::HEAD)
+        return "Head";
+    if (iBoneID == eBoneType::JAW)
+        return "Jaw";
+    if (iBoneID == eBoneType::L_BROW)
+        return "L Brow";
+    if (iBoneID == eBoneType::R_BROW)
+        return "R Brow";
+    if (iBoneID == eBoneType::L_CLAVICLE)
+        return "Bip01 L Clavicle";
+    if (iBoneID == eBoneType::L_UPPER_ARM)
+        return "L UpperArm";
+    if (iBoneID == eBoneType::L_FORE_ARM)
+        return "L ForeArm";
+    if (iBoneID == eBoneType::L_HAND)
+        return "L Hand";
+
+    if (iBoneID == eBoneType::L_FINGER)
+        return "L Finger";
+
+    if (iBoneID == eBoneType::L_FINGER_01)
+        return "L Finger01";
+    if (iBoneID == eBoneType::R_CLAVICLE)
+        return "Bip01 R Clavicle";
+    if (iBoneID == eBoneType::R_UPPER_ARM)
+        return "R UpperArm";
+    if (iBoneID == eBoneType::R_FORE_ARM)
+        return "R ForeArm";
+    if (iBoneID == eBoneType::R_HAND)
+        return "R Hand";
+
+    if (iBoneID == eBoneType::R_FINGER)
+        return "R Finger";
+
+    if (iBoneID == eBoneType::R_FINGER_01)
+        return "R Finger01";
+    if (iBoneID == eBoneType::L_BREAST)
+        return "L breast";
+    if (iBoneID == eBoneType::R_BREAST)
+        return "R breast";
+    if (iBoneID == eBoneType::BELLY)
+        return "Belly";
+    if (iBoneID == eBoneType::L_THIGH)
+        return "L Thigh";
+    if (iBoneID == eBoneType::L_CALF)
+        return "L Calf";
+    if (iBoneID == eBoneType::L_FOOT)
+        return "L Foot";
+    if (iBoneID == eBoneType::L_TOE_0)
+        return "L Toe0";
+    if (iBoneID == eBoneType::R_THIGH)
+        return "R Thigh";
+    if (iBoneID == eBoneType::R_CALF)
+        return "R Calf";
+    if (iBoneID == eBoneType::R_FOOT)
+        return "R Foot";
+    if (iBoneID == eBoneType::R_TOE_0)
+        return "R Toe0";
+
+    return "";
+}
+
+SString CClientIFP::GetCorrectBoneNameFromName(const SString& strBoneName)
+{
+    if (strBoneName == "root")
+        return "Normal";
+    if (strBoneName == "normal")
+        return "Normal";
+
+    if (strBoneName == "pelvis")
+        return "Pelvis";
+    if (strBoneName == "spine")
+        return "Spine";
+    if (strBoneName == "spine1")
+        return "Spine1";
+    if (strBoneName == "neck")
+        return "Neck";
+    if (strBoneName == "head")
+        return "Head";
+    if (strBoneName == "jaw")
+        return "Jaw";
+    if (strBoneName == "lbrow")
+        return "L Brow";
+    if (strBoneName == "rbrow")
+        return "R Brow";
+    if (strBoneName == "bip01lclavicle")
+        return "Bip01 L Clavicle";
+    if (strBoneName == "lupperarm")
+        return "L UpperArm";
+    if (strBoneName == "lforearm")
+        return "L ForeArm";
+    if (strBoneName == "lhand")
+        return "L Hand";
+
+    if (strBoneName == "lfingers")
+        return "L Finger";
+    if (strBoneName == "lfinger")
+        return "L Finger";
+
+    if (strBoneName == "lfinger01")
+        return "L Finger01";
+    if (strBoneName == "bip01rclavicle")
+        return "Bip01 R Clavicle";
+    if (strBoneName == "rupperarm")
+        return "R UpperArm";
+    if (strBoneName == "rforearm")
+        return "R ForeArm";
+    if (strBoneName == "rhand")
+        return "R Hand";
+
+    if (strBoneName == "rfingers")
+        return "R Finger";
+    if (strBoneName == "rfinger")
+        return "R Finger";
+
+    if (strBoneName == "rfinger01")
+        return "R Finger01";
+    if (strBoneName == "lbreast")
+        return "L Breast";
+    if (strBoneName == "rbreast")
+        return "R Breast";
+    if (strBoneName == "belly")
+        return "Belly";
+    if (strBoneName == "lthigh")
+        return "L Thigh";
+    if (strBoneName == "lcalf")
+        return "L Calf";
+    if (strBoneName == "lfoot")
+        return "L Foot";
+    if (strBoneName == "ltoe0")
+        return "L Toe0";
+    if (strBoneName == "rthigh")
+        return "R Thigh";
+    if (strBoneName == "rcalf")
+        return "R Calf";
+    if (strBoneName == "rfoot")
+        return "R Foot";
+    if (strBoneName == "rtoe0")
+        return "R Toe0";
+
+    // For GTA 3
+    if (strBoneName == "player")
+        return "Normal";
+    if (strBoneName == "swaist")
+        return "Pelvis";
+    if (strBoneName == "smid")
+        return "Spine";
+    if (strBoneName == "storso")
+        return "Spine1";
+    if (strBoneName == "shead")
+        return "Head";
+
+    if (strBoneName == "supperarml")
+        return "L UpperArm";
+    if (strBoneName == "slowerarml")
+        return "L ForeArm";
+    if (strBoneName == "supperarmr")
+        return "R UpperArm";
+    if (strBoneName == "slowerarmr")
+        return "R ForeArm";
+
+    if (strBoneName == "srhand")
+        return "R Hand";
+    if (strBoneName == "slhand")
+        return "L Hand";
+    if (strBoneName == "supperlegr")
+        return "R Thigh";
+    if (strBoneName == "slowerlegr")
+        return "R Calf";
+    if (strBoneName == "sfootr")
+        return "R Foot";
+    if (strBoneName == "supperlegl")
+        return "L Thigh";
+    if (strBoneName == "slowerlegl")
+        return "L Calf";
+    if (strBoneName == "sfootl")
+        return "L Foot";
+
+    return strBoneName;
+}
+
+CAnimBlendHierarchySAInterface* CClientIFP::GetAnimationHierarchy(const SString& strAnimationName)
+{
+    const unsigned int uiAnimationNameHash = HashString(strAnimationName.ToLower());
+    auto               it = std::find_if(m_pVecAnimations->begin(), m_pVecAnimations->end(),
+                           [&uiAnimationNameHash](SAnimation const& Animation) { return Animation.uiNameHash == uiAnimationNameHash; });
+    if (it != m_pVecAnimations->end())
+    {
+        return it->pHierarchy->GetInterface();
+    }
+    return nullptr;
+}

--- a/Client/mods/deathmatch/logic/CClientIFP.h
+++ b/Client/mods/deathmatch/logic/CClientIFP.h
@@ -1,0 +1,297 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CClientIFP.h
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#ifndef __CCLIENTIFP_H
+#define __CCLIENTIFP_H
+#pragma once
+
+#include "CClientEntity.h"
+#include "CFileReader.h"
+#include "CIFPAnimations.h"
+
+class CClientIFP : public CClientEntity, CFileReader
+{
+public:
+    typedef CIFPAnimations::SAnimation                           SAnimation;
+    typedef std::map<DWORD, std::unique_ptr<CAnimBlendSequence>> SequenceMapType;
+
+    struct SBase
+    {
+        char          FourCC[4];
+        std::uint32_t Size;
+    };
+
+    struct SInfo
+    {
+        SBase        Base;
+        std::int32_t Entries;
+        char         Name[24];
+    };
+
+    struct SAnpk
+    {
+        SBase Base;
+        SInfo Info;
+    };
+
+    struct SName
+    {
+        SBase Base;
+    };
+
+    struct SDgan
+    {
+        SBase Base;
+        SInfo Info;
+    };
+
+    struct SCpan
+    {
+        SBase Base;
+    };
+
+    struct SAnim
+    {
+        SBase        Base;
+        char         Name[28];
+        std::int32_t Frames;
+        std::int32_t Unk;
+        std::int32_t Next;
+        std::int32_t Previous;
+
+        // According to https://www.gtamodding.com/wiki/IFP, Unk2 should not exist, but for some reason, it's there
+        // I don't know why. Let's just go with the flow and ignore it. The value seems to be always zero.
+        std::int32_t Unk2;
+    };
+
+    struct SKfrm
+    {
+        SBase Base;
+    };
+
+    struct SQuaternion
+    {
+        float X, Y, Z, W;
+    };
+
+    struct SVector
+    {
+        float X, Y, Z;
+    };
+
+    struct SKr00
+    {
+        SQuaternion Rotation;
+        float       Time;
+    };
+
+    struct SKrt0
+    {
+        SQuaternion Rotation;
+        SVector     Translation;
+        float       Time;
+    };
+
+    struct SKrts
+    {
+        SQuaternion Rotation;
+        SVector     Translation;
+        SVector     Scale;
+        float       Time;
+    };
+
+    struct SCompressedQuaternion
+    {
+        std::int16_t X, Y, Z, W;
+    };
+
+    struct SCompressedCVector
+    {
+        std::int16_t X, Y, Z;
+    };
+
+    struct SCompressed_KR00
+    {
+        SCompressedQuaternion Rotation;
+        std::int16_t          Time;
+    };
+
+    struct SCompressed_KRT0 : SCompressed_KR00
+    {
+        SCompressedCVector Translation;
+    };
+
+    enum eFrameType
+    {
+        UNKNOWN_FRAME = -1,
+        KR00 = 0,
+        KRT0 = 1,
+        KRTS = 2,
+        KR00_COMPRESSED = 3,
+        KRT0_COMPRESSED = 4,
+    };
+
+    struct SIFPHeaderV2
+    {
+        std::uint32_t OffsetEOF;
+        char          InternalFileName[24];
+        std::int32_t  TotalAnimations;
+    };
+
+    struct SAnimationHeaderV2
+    {
+        char         Name[24];
+        std::int32_t TotalObjects;
+        std::int32_t FrameSize;
+        std::int32_t isCompressed;            // The value is always 1
+    };
+
+    struct SSequenceHeaderV2
+    {
+        char         Name[24];
+        std::int32_t FrameType;
+        std::int32_t TotalFrames;
+        std::int32_t BoneID;
+    };
+
+    enum eBoneType
+    {
+        UNKNOWN = -1,
+        NORMAL = 0,            // Normal or Root, both are same
+        PELVIS = 1,
+        SPINE = 2,
+        SPINE1 = 3,
+        NECK = 4,
+        HEAD = 5,
+        JAW = 8,
+        L_BROW = 6,
+        R_BROW = 7,
+        L_CLAVICLE = 31,
+        L_UPPER_ARM = 32,
+        L_FORE_ARM = 33,
+        L_HAND = 34,
+        L_FINGER = 35,
+        L_FINGER_01 = 36,
+        R_CLAVICLE = 21,
+        R_UPPER_ARM = 22,
+        R_FORE_ARM = 23,
+        R_HAND = 24,
+        R_FINGER = 25,
+        R_FINGER_01 = 26,
+        L_BREAST = 302,
+        R_BREAST = 301,
+        BELLY = 201,
+        L_THIGH = 41,
+        L_CALF = 42,
+        L_FOOT = 43,
+        L_TOE_0 = 44,
+        R_THIGH = 51,
+        R_CALF = 52,
+        R_FOOT = 53,
+        R_TOE_0 = 54
+    };
+
+    CClientIFP(class CClientManager* pManager, ElementID ID);
+
+    virtual eClientEntityType GetType(void) const { return CCLIENTIFP; }
+
+    void MarkAsUnloading(void) { m_bUnloading = true; }
+    bool IsUnloading(void) { return m_bUnloading; }
+
+    bool LoadIFP(const SString& strFilePath, const SString& strBlockName);
+
+    const SString&      GetBlockName(void) { return m_strBlockName; }
+    const unsigned int& GetBlockNameHash(void) { return m_u32Hashkey; }
+
+    CAnimBlendHierarchySAInterface* GetAnimationHierarchy(const SString& strAnimationName);
+    std::shared_ptr<CIFPAnimations> GetIFPAnimationsPointer(void) { return m_pIFPAnimations; }
+
+    // Sorta a hack that these are required by CClientEntity...
+    void Unlink(void){};
+    void GetPosition(CVector& vecPosition) const {};
+    void SetPosition(const CVector& vecPosition){};
+
+private:
+    bool LoadIFPFile(const SString& strFilePath);
+    bool ReadIFPByVersion(void);
+    void ReadIFPVersion1(void);
+    void ReadIFPVersion2(bool bAnp3);
+
+    WORD         ReadSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy);
+    WORD         ReadSequences(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences);
+    WORD         ReadSequencesVersion1(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences);
+    WORD         ReadSequencesVersion2(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences);
+    std::int32_t ReadSequenceVersion1(SAnim& Anim);
+    void         ReadSequenceVersion2(SSequenceHeaderV2& ObjectNode);
+
+    void                   ReadHeaderVersion1(SInfo& Info);
+    void                   ReadAnimationNameVersion1(SAnimation& IfpAnimation);
+    void                   ReadDgan(SDgan& Dgan);
+    CClientIFP::eFrameType ReadKfrm(void);
+    void                   ReadAnimationHeaderVersion2(SAnimationHeaderV2& AnimationNode, bool bAnp3);
+
+    bool ReadSequenceKeyFrames(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, eFrameType iFrameType, const std::int32_t& cFrames);
+    void ReadKeyFramesAsCompressed(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, eFrameType iFrameType, const std::int32_t& cFrames);
+    void ReadKrtsFramesAsCompressed(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const std::int32_t& cFrames);
+    void ReadKrt0FramesAsCompressed(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const std::int32_t& cFrames);
+    void ReadKr00FramesAsCompressed(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const std::int32_t& cFrames);
+
+    template <class T>
+    void ReadCompressedFrames(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, std::int32_t iFrames)
+    {
+        BYTE*  pKeyFrames = pAnimationSequence->GetKeyFrames();
+        size_t iSizeInBytes = sizeof(T) * iFrames;
+        ReadBytes(pKeyFrames, iSizeInBytes);
+    }
+
+    void  InitializeAnimationHierarchy(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, const SString& strAnimationName,
+                                       const std::int32_t& iSequences);
+    void  InitializeAnimationSequence(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const SString& strName, const std::int32_t& iBoneID);
+    void  PreProcessAnimationHierarchy(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy);
+    void  MoveSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>&                 pAnimationHierarchy,
+                                   std::map<DWORD, std::unique_ptr<CAnimBlendSequence>>& mapOfSequences);
+    BYTE* AllocateSequencesMemory(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy);
+
+    void    InsertAnimationDummySequence(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const SString& BoneName, const DWORD& dwBoneID);
+    void    CopyDummyKeyFrameByBoneID(BYTE* pKeyFrames, DWORD dwBoneID);
+    SString ConvertStringToKey(const SString& strBoneName);
+
+    constexpr void RoundSize(std::uint32_t& u32Size);
+    constexpr bool IsKeyFramesTypeRoot(eFrameType iFrameType);
+
+    eFrameType   GetFrameTypeFromFourCC(const char* szFourCC);
+    size_t       GetSizeOfCompressedFrame(eFrameType FrameType);
+    std::int32_t GetBoneIDFromName(const SString& strBoneName);
+    SString      GetCorrectBoneNameFromName(const SString& strBoneName);
+    SString      GetCorrectBoneNameFromID(const std::int32_t& iBoneID);
+
+    std::shared_ptr<CIFPAnimations> m_pIFPAnimations;
+    SString                         m_strBlockName;
+    unsigned int                    m_u32Hashkey;
+    std::vector<SAnimation>*        m_pVecAnimations;
+    bool                            m_bVersion1;
+    bool                            m_bUnloading;
+    CAnimManager*                   m_pAnimManager;
+
+    // 32 because there are 32 bones in a ped model
+    const unsigned short m_kcIFPSequences = 32;
+    // We'll keep all key frames compressed by default. GTA:SA will decompress
+    // them, when it's going to play the animation. We don't need to worry about it.
+    const bool m_kbAllKeyFramesCompressed = true;
+
+    const DWORD m_karruBoneIds[32] = {0, 1, 2, 3, 4, 5, 8, 6, 7, 31, 32, 33, 34, 35, 36, 21, 22, 23, 24, 25, 26, 302, 301, 201, 41, 42, 43, 44, 51, 52, 53, 54};
+    const char  m_karrstrBoneNames[32][24] = {
+        "Normal",     "Pelvis",           "Spine",      "Spine1",    "Neck",       "Head",     "Jaw",        "L Brow",
+        "R Brow",     "Bip01 L Clavicle", "L UpperArm", "L ForeArm", "L Hand",     "L Finger", "L Finger01", "Bip01 R Clavicle",
+        "R UpperArm", "R ForeArm",        "R Hand",     "R Finger",  "R Finger01", "L breast", "R breast",   "Belly",
+        "L Thigh",    "L Calf",           "L Foot",     "L Toe0",    "R Thigh",    "R Calf",   "R Foot",     "R Toe0"};
+};
+
+#endif

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -9,7 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
-
+#include "game/CAnimBlendHierarchy.h"
 using std::list;
 using std::vector;
 
@@ -90,6 +90,12 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
 
     m_pRequester = pManager->GetModelRequestManager();
 
+    m_bisNextAnimationCustom = false;
+    m_bisCurrentAnimationCustom = false;
+    m_strCustomIFPBlockName = "Default";
+    m_strCustomIFPAnimationName = "Default";
+    m_u32CustomBlockNameHash = 0;
+    m_u32CustomAnimationNameHash = 0;
     m_iVehicleInOutState = VEHICLE_INOUT_NONE;
     m_pPlayerPed = NULL;
     m_pTaskManager = NULL;
@@ -233,10 +239,14 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
 
         SetArmor(0.0f);
     }
+
+    g_pClientGame->InsertPedPointerToSet(this);
 }
 
 CClientPed::~CClientPed(void)
 {
+    g_pClientGame->RemovePedPointerFromSet(this);
+
     // Remove from the ped manager
     m_pManager->GetPedManager()->RemoveFromList(this);
 
@@ -991,6 +1001,11 @@ bool CClientPed::SetModel(unsigned long ulModel, bool bTemp)
         // Different model from what we have now?
         if (m_ulModel != ulModel)
         {
+            if (m_bisCurrentAnimationCustom)
+            {
+                m_bisNextAnimationCustom = true;
+            }
+
             if (bTemp)
                 m_ulStoredModel = m_ulModel;
 
@@ -2774,6 +2789,11 @@ void CClientPed::StreamedInPulse(bool bDoStandardPulses)
             // Is it loaded now?
             if (m_pAnimationBlock->IsLoaded())
             {
+                if (m_bisCurrentAnimationCustom)
+                {
+                    m_bisNextAnimationCustom = true;
+                }
+
                 m_bRequestedAnimation = false;
 
                 // Copy our name incase it gets deleted
@@ -3621,6 +3641,10 @@ void CClientPed::_CreateModel(void)
         // Are we still playing a looped animation?
         if (m_bLoopAnimation && m_pAnimationBlock)
         {
+            if (m_bisCurrentAnimationCustom)
+            {
+                m_bisNextAnimationCustom = true;
+            }
             // Copy our anim name incase it gets deleted
             SString strAnimName = m_strAnimationName;
             // Run our animation
@@ -3914,6 +3938,11 @@ void CClientPed::_ChangeModel(void)
             // Are we still playing a looped animation?
             if (m_bLoopAnimation && m_pAnimationBlock)
             {
+                if (m_bisCurrentAnimationCustom)
+                {
+                    m_bisNextAnimationCustom = true;
+                }
+
                 // Copy our anim name incase it gets deleted
                 SString strAnimName = m_strAnimationName;
                 // Run our animation
@@ -5108,6 +5137,7 @@ void CClientPed::Respawn(CVector* pvecPosition, bool bRestoreState, bool bCamera
     // We must not call CPed::Respawn for remote players
     if (m_bIsLocalPlayer)
     {
+        SetNextAnimationNormal();
         SetFrozenWaitingForGroundToLoad(true);
         if (m_pPlayerPed)
         {
@@ -5630,7 +5660,11 @@ void CClientPed::RunNamedAnimation(CAnimBlock* pBlock, const char* szAnimName, i
 
         if (pBlock->IsLoaded())
         {
-            int flags = 0x10;            // // Stops jaw fucking up, some speaking flag maybe
+            /*
+             Saml1er: Setting flags to 0x10 will tell GTA:SA that animation needs to be decompressed.
+                      If not, animation will either crash or do some weird things.
+            */
+            int flags = 0x10;            // Stops jaw fucking up, some speaking flag maybe
             if (bLoop)
                 flags |= 0x2;            // flag that triggers the loop (Maccer)
             if (bUpdatePosition)
@@ -5699,6 +5733,7 @@ void CClientPed::KillAnimation(void)
     m_pAnimationBlock = NULL;
     m_strAnimationName = "";
     m_bRequestedAnimation = false;
+    SetNextAnimationNormal();
 }
 
 void CClientPed::PostWeaponFire(void)
@@ -5988,6 +6023,67 @@ CAnimBlendAssociation* CClientPed::GetFirstAnimation(void)
         return g_pGame->GetAnimManager()->RpAnimBlendClumpGetFirstAssociation(m_pPlayerPed->GetRpClump());
     }
     return NULL;
+}
+
+void CClientPed::SetNextAnimationCustom(const std::shared_ptr<CClientIFP>& pIFP, const SString& strAnimationName)
+{
+    m_bisNextAnimationCustom = true;
+    m_pCustomAnimationIFP = pIFP;
+    m_strCustomIFPBlockName = pIFP->GetBlockName();
+    m_strCustomIFPAnimationName = strAnimationName;
+    m_u32CustomBlockNameHash = pIFP->GetBlockNameHash();
+    m_u32CustomAnimationNameHash = HashString(strAnimationName.ToLower());
+}
+
+void CClientPed::ReplaceAnimation(CAnimBlendHierarchy* pInternalAnimHierarchy, const std::shared_ptr<CClientIFP>& pIFP,
+                                  CAnimBlendHierarchySAInterface* pCustomAnimHierarchy)
+{
+    SReplacedAnimation replacedAnimation;
+    replacedAnimation.pIFP = pIFP;
+    replacedAnimation.pAnimationHierarchy = pCustomAnimHierarchy;
+    m_mapOfReplacedAnimations[pInternalAnimHierarchy->GetInterface()] = replacedAnimation;
+}
+
+void CClientPed::RestoreAnimation(CAnimBlendHierarchy* pInternalAnimHierarchy)
+{
+    m_mapOfReplacedAnimations.erase(pInternalAnimHierarchy->GetInterface());
+}
+
+void CClientPed::RestoreAnimations(const std::shared_ptr<CClientIFP>& IFP)
+{
+    for (auto const& x : m_mapOfReplacedAnimations)
+    {
+        if (std::addressof(*IFP.get()) == std::addressof(*x.second.pIFP.get()))
+        {
+            m_mapOfReplacedAnimations.erase(x.first);
+        }
+    }
+}
+
+void CClientPed::RestoreAnimations(CAnimBlock& animationBlock)
+{
+    const size_t cAnimations = animationBlock.GetAnimationCount();
+    for (size_t i = 0; i < cAnimations; i++)
+    {
+        auto pAnimHierarchyInterface = animationBlock.GetAnimationHierarchyInterface(i);
+        m_mapOfReplacedAnimations.erase(pAnimHierarchyInterface);
+    }
+}
+
+void CClientPed::RestoreAllAnimations(void)
+{
+    m_mapOfReplacedAnimations.clear();
+}
+
+SReplacedAnimation* CClientPed::GetReplacedAnimation(CAnimBlendHierarchySAInterface* pInternalHierarchyInterface)
+{
+    CClientPed::ReplacedAnim_type::iterator it;
+    it = m_mapOfReplacedAnimations.find(pInternalHierarchyInterface);
+    if (it != m_mapOfReplacedAnimations.end())
+    {
+        return &it->second;
+    }
+    return nullptr;
 }
 
 CSphere CClientPed::GetWorldBoundingSphere(void)

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -19,6 +19,7 @@ class CClientPed;
 
 #include <multiplayer/CMultiplayer.h>
 #include "CClientPad.h"
+#include <memory>
 
 class CClientCamera;
 class CClientManager;
@@ -111,6 +112,14 @@ struct SRestoreWeaponItem
     eWeaponType eWeaponID;
 };
 
+class CClientIFP;
+
+struct SReplacedAnimation
+{
+    std::shared_ptr<CClientIFP>     pIFP;
+    CAnimBlendHierarchySAInterface* pAnimationHierarchy;
+};
+
 class CClientObject;
 
 // To hide the ugly "pointer truncation from DWORD* to unsigned long warning
@@ -119,6 +128,7 @@ class CClientObject;
 class CClientPed : public CClientStreamElement, public CAntiCheatModule
 {
     DECLARE_CLASS(CClientPed, CClientStreamElement)
+    typedef std::map<CAnimBlendHierarchySAInterface*, SReplacedAnimation> ReplacedAnim_type;
     friend class CClientCamera;
     friend class CClientPlayer;
     friend class CClientVehicle;
@@ -460,6 +470,37 @@ public:
     CAnimBlendAssociation* GetAnimation(AnimationId id);
     CAnimBlendAssociation* GetFirstAnimation(void);
 
+    void                        DereferenceCustomAnimationBlock(void) { m_pCustomAnimationIFP = nullptr; }
+    std::shared_ptr<CClientIFP> GetCustomAnimationIFP(void) { return m_pCustomAnimationIFP; }
+    bool IsCustomAnimationPlaying(void) { return ((m_bRequestedAnimation || m_bLoopAnimation) && m_pAnimationBlock && m_bisCurrentAnimationCustom); }
+    void SetCustomAnimationUntriggerable(void)
+    {
+        m_bRequestedAnimation = false;
+        m_bLoopAnimation = false;
+    }
+    bool            IsNextAnimationCustom(void) { return m_bisNextAnimationCustom; }
+    void            SetNextAnimationCustom(const std::shared_ptr<CClientIFP>& pIFP, const SString& strAnimationName);
+    void            SetCurrentAnimationCustom(bool bCustom) { m_bisCurrentAnimationCustom = bCustom; }
+    bool            IsCurrentAnimationCustom(void) { return m_bisCurrentAnimationCustom; }
+    CIFPAnimations* GetIFPAnimationsPointer(void) { return m_pIFPAnimations; }
+    void            SetIFPAnimationsPointer(CIFPAnimations* pIFPAnimations) { m_pIFPAnimations = pIFPAnimations; }
+
+    // This will indicate that we have played custom animation, so next animation can be internal GTA animation
+    // You must call this function after playing a custom animation
+    void                SetNextAnimationNormal(void) { m_bisNextAnimationCustom = false; }
+    const SString&      GetNextAnimationCustomBlockName(void) { return m_strCustomIFPBlockName; }
+    const SString&      GetNextAnimationCustomName(void) { return m_strCustomIFPAnimationName; }
+    const unsigned int& GetCustomAnimationBlockNameHash(void) { return m_u32CustomBlockNameHash; }
+    const unsigned int& GetCustomAnimationNameHash(void) { return m_u32CustomAnimationNameHash; }
+
+    void                ReplaceAnimation(CAnimBlendHierarchy* pInternalAnimHierarchy, const std::shared_ptr<CClientIFP>& pIFP,
+                                         CAnimBlendHierarchySAInterface* pCustomAnimHierarchy);
+    void                RestoreAnimation(CAnimBlendHierarchy* pInternalAnimHierarchy);
+    void                RestoreAnimations(const std::shared_ptr<CClientIFP>& IFP);
+    void                RestoreAnimations(CAnimBlock& animationBlock);
+    void                RestoreAllAnimations(void);
+    SReplacedAnimation* GetReplacedAnimation(CAnimBlendHierarchySAInterface* pInternalHierarchyInterface);
+
 protected:
     // This constructor is for peds managed by a player. These are unknown to the ped manager.
     CClientPed(CClientManager* pManager, unsigned long ulModelID, ElementID ID, bool bIsLocalPlayer);
@@ -653,6 +694,20 @@ public:
 
     CVector m_vecPrevTargetPosition;
     uint    m_uiForceLocalCounter;
+
+    // This is checked within AddAnimation and AddAnimationAndSync
+    // It is set to false when custom animation is played.
+    bool                        m_bisNextAnimationCustom;
+    bool                        m_bisCurrentAnimationCustom;
+    SString                     m_strCustomIFPBlockName;
+    SString                     m_strCustomIFPAnimationName;
+    unsigned int                m_u32CustomBlockNameHash;
+    unsigned int                m_u32CustomAnimationNameHash;
+    CIFPAnimations*             m_pIFPAnimations;
+    std::shared_ptr<CClientIFP> m_pCustomAnimationIFP;
+
+    // Key: Internal GTA animation, Value: Custom Animation
+    ReplacedAnim_type m_mapOfReplacedAnimations;
 };
 
 #endif

--- a/Client/mods/deathmatch/logic/CElementDeleter.h
+++ b/Client/mods/deathmatch/logic/CElementDeleter.h
@@ -12,6 +12,7 @@
 #ifndef __CELEMENTDELETER_H
 #define __CELEMENTDELETER_H
 
+#include <memory>
 #include <list>
 
 class CElementDeleter
@@ -22,9 +23,12 @@ public:
 
     void Delete(class CClientEntity* pElement);
     void DeleteRecursive(class CClientEntity* pElement);
+    bool DeleteElementSpecial(CClientEntity* pElement);
+    void DeleteIFP(CClientEntity* pElement);
 
     void DoDeleteAll(void);
-
+    bool OnClientSpecialElementDestroy(CClientEntity* pElement);
+    void OnClientIFPElementDestroy(CClientEntity* pElement);
     bool IsBeingDeleted(class CClientEntity* pElement);
 
     void Unreference(class CClientEntity* pElement);
@@ -33,7 +37,10 @@ public:
 
 private:
     CMappedList<class CClientEntity*> m_List;
-    bool                              m_bAllowUnreference;
+    // We are using shared_ptr for CClientIFP, and we must keep a reference
+    // somewhere, so this is it.
+    std::vector<std::shared_ptr<class CClientIFP> > m_vecIFPElements;
+    bool                                            m_bAllowUnreference;
 };
 
 #endif

--- a/Client/mods/deathmatch/logic/CFileReader.cpp
+++ b/Client/mods/deathmatch/logic/CFileReader.cpp
@@ -1,0 +1,61 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CFileReader.cpp
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include <StdInc.h>
+#include <fstream>
+
+CFileReader::CFileReader(void)
+{
+    m_u32BytesReadFromBuffer = 0;
+}
+
+void CFileReader::FreeFileReaderMemory(void)
+{
+    std::vector<char>().swap(m_vecFileDataBuffer);
+    m_u32BytesReadFromBuffer = 0;
+}
+
+void CFileReader::ReadBytes(void* pDestination, const std::uint32_t u32BytesToRead)
+{
+    const std::uint32_t u32ReadOffset = m_u32BytesReadFromBuffer;
+    m_u32BytesReadFromBuffer += u32BytesToRead;
+    memcpy(pDestination, &m_vecFileDataBuffer[u32ReadOffset], u32BytesToRead);
+}
+
+void CFileReader::ReadStringNullTerminated(char* pDestination, const std::uint32_t u32BytesToRead)
+{
+    const std::uint32_t u32ReadOffset = m_u32BytesReadFromBuffer;
+    m_u32BytesReadFromBuffer += u32BytesToRead;
+    memcpy(pDestination, &m_vecFileDataBuffer[u32ReadOffset], u32BytesToRead);
+    *(pDestination + (u32BytesToRead - 1)) = '\0';
+}
+
+void CFileReader::SkipBytes(const std::uint32_t u32BytesToSkip)
+{
+    m_u32BytesReadFromBuffer += u32BytesToSkip;
+}
+
+bool CFileReader::LoadFileToMemory(const SString& strFilePath)
+{
+    std::ifstream   fileStream(strFilePath, std::ios::binary | std::ios::ate);
+    std::streamsize m_iFileSize = fileStream.tellg();
+    if (m_iFileSize == eIFSTREAM::SIZE_ERROR)
+    {
+        return false;
+    }
+
+    fileStream.seekg(0, std::ios::beg);
+    m_vecFileDataBuffer.reserve(static_cast<size_t>(m_iFileSize));
+    if (fileStream.read(m_vecFileDataBuffer.data(), m_iFileSize))
+    {
+        return true;
+    }
+    return false;
+}

--- a/Client/mods/deathmatch/logic/CFileReader.h
+++ b/Client/mods/deathmatch/logic/CFileReader.h
@@ -1,0 +1,47 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CFileReader.h
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#ifndef CFILEREADER_H
+#define CFILEREADER_H
+#pragma once
+
+#include <cstdint>
+
+class CFileReader
+{
+public:
+    enum eIFSTREAM
+    {
+        SIZE_ERROR = -1
+    };
+
+    CFileReader(void);
+    bool LoadFileToMemory(const SString& strFilePath);
+    // Do not call any file reader functions after calling this function
+    void FreeFileReaderMemory(void);
+
+    template <class T>
+    void ReadBuffer(T* pDestination)
+    {
+        const std::uint32_t u32ReadOffset = m_u32BytesReadFromBuffer;
+        m_u32BytesReadFromBuffer += sizeof(T);
+        *pDestination = *reinterpret_cast<T*>(&m_vecFileDataBuffer[u32ReadOffset]);
+    }
+
+    void ReadBytes(void* pDestination, const std::uint32_t u32BytesToRead);
+    void ReadStringNullTerminated(char* pDestination, const std::uint32_t u32BytesToRead);
+    void SkipBytes(const std::uint32_t u32BytesToSkip);
+
+private:
+    std::vector<char> m_vecFileDataBuffer;
+    std::uint32_t     m_u32BytesReadFromBuffer;
+};
+
+#endif

--- a/Client/mods/deathmatch/logic/CIFPAnimations.cpp
+++ b/Client/mods/deathmatch/logic/CIFPAnimations.cpp
@@ -1,0 +1,48 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CIFPAnimations.cpp
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include <StdInc.h>
+#include "game/CAnimBlendSequence.h"
+#include "game/CAnimBlendHierarchy.h"
+
+CIFPAnimations::~CIFPAnimations(void)
+{
+    DeleteAnimations();
+}
+
+void CIFPAnimations::DeleteAnimations(void)
+{
+    CAnimManager* pAnimManager = g_pGame->GetAnimManager();
+    for (auto& Animation : vecAnimations)
+    {
+        for (unsigned short SequenceIndex = 0; SequenceIndex < Animation.pHierarchy->GetNumSequences(); SequenceIndex++)
+        {
+            pAnimManager->RemoveFromUncompressedCache(Animation.pHierarchy->GetInterface());
+            auto  pAnimationSequence = pAnimManager->GetCustomAnimBlendSequence(Animation.pHierarchy->GetSequence(SequenceIndex));
+            void* pKeyFrames = pAnimationSequence->GetKeyFrames();
+            if (!pAnimationSequence->IsBigChunkForAllSequences())
+            {
+                pAnimManager->FreeKeyFramesMemory(pKeyFrames);
+            }
+            else
+            {
+                if (SequenceIndex == 0)
+                {
+                    // All frames of all sequences are allocated on one memory block, so free that one
+                    // and break the loop
+                    pAnimManager->FreeKeyFramesMemory(pKeyFrames);
+                    break;
+                }
+            }
+        }
+        delete Animation.pSequencesMemory;
+        pAnimManager->DeleteCustomAnimHierarchyInterface(Animation.pHierarchy->GetInterface());
+    }
+}

--- a/Client/mods/deathmatch/logic/CIFPAnimations.h
+++ b/Client/mods/deathmatch/logic/CIFPAnimations.h
@@ -1,0 +1,34 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CIFPAnimations.h
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#ifndef __CIFPANIMATIONS_H
+#define __CIFPANIMATIONS_H
+#pragma once
+
+#include "CClientIFP.h"
+
+class CIFPAnimations
+{
+public:
+    struct SAnimation
+    {
+        SString                              Name;
+        unsigned int                         uiNameHash;
+        std::unique_ptr<CAnimBlendHierarchy> pHierarchy;
+        BYTE*                                pSequencesMemory;
+    };
+
+    std::vector<SAnimation> vecAnimations;
+
+public:
+    ~CIFPAnimations(void);
+    void DeleteAnimations(void);
+};
+#endif

--- a/Client/mods/deathmatch/logic/CIFPEngine.cpp
+++ b/Client/mods/deathmatch/logic/CIFPEngine.cpp
@@ -1,0 +1,101 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CIFPEngine.cpp
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include <StdInc.h>
+
+std::shared_ptr<CClientIFP> CIFPEngine::EngineLoadIFP(CResource* pResource, CClientManager* pManager, const SString& strPath, const SString& strBlockName)
+{
+    // Grab the resource root entity
+    CClientEntity*     pRoot = pResource->GetResourceIFPRoot();
+    const unsigned int u32BlockNameHash = HashString(strBlockName.ToLower());
+
+    // Check whether the IFP blockname exists or not
+    if (g_pClientGame->GetIFPPointerFromMap(u32BlockNameHash) == nullptr)
+    {
+        // Create a IFP element
+        std::shared_ptr<CClientIFP> pIFP(new CClientIFP(pManager, INVALID_ELEMENT_ID));
+
+        // Try to load the IFP file
+        if (pIFP->LoadIFP(strPath, strBlockName))
+        {
+            // We can use the map to retrieve correct IFP by block name later
+            g_pClientGame->InsertIFPPointerToMap(u32BlockNameHash, pIFP);
+
+            // Success loading the file. Set parent to IFP root
+            pIFP->SetParent(pRoot);
+            return pIFP;
+        }
+    }
+    return nullptr;
+}
+
+bool CIFPEngine::EngineReplaceAnimation(CClientEntity* pEntity, const SString& strInternalBlockName, const SString& strInternalAnimName,
+                                        const SString& strCustomBlockName, const SString& strCustomAnimName)
+{
+    if (IS_PED(pEntity))
+    {
+        CClientPed& Ped = static_cast<CClientPed&>(*pEntity);
+
+        const unsigned int          u32BlockNameHash = HashString(strCustomBlockName.ToLower());
+        CAnimBlock*                 pInternalBlock = g_pGame->GetAnimManager()->GetAnimationBlock(strInternalBlockName);
+        std::shared_ptr<CClientIFP> pCustomIFP = g_pClientGame->GetIFPPointerFromMap(u32BlockNameHash);
+        if (pInternalBlock && pCustomIFP)
+        {
+            // Try to load the block, if it's not loaded already
+            pInternalBlock->Request(BLOCKING, true);
+
+            CAnimBlendHierarchy*            pInternalAnimHierarchy = g_pGame->GetAnimManager()->GetAnimation(strInternalAnimName, pInternalBlock);
+            CAnimBlendHierarchySAInterface* pCustomAnimHierarchyInterface = pCustomIFP->GetAnimationHierarchy(strCustomAnimName);
+            if (pInternalAnimHierarchy && pCustomAnimHierarchyInterface)
+            {
+                Ped.ReplaceAnimation(pInternalAnimHierarchy, pCustomIFP, pCustomAnimHierarchyInterface);
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool CIFPEngine::EngineRestoreAnimation(CClientEntity* pEntity, const SString& strInternalBlockName, const SString& strInternalAnimName,
+                                        const eRestoreAnimation& eRestoreType)
+{
+    if (IS_PED(pEntity))
+    {
+        CClientPed& Ped = static_cast<CClientPed&>(*pEntity);
+
+        if (eRestoreType == eRestoreAnimation::ALL)
+        {
+            Ped.RestoreAllAnimations();
+            return true;
+        }
+        else
+        {
+            CAnimBlock* pInternalBlock = g_pGame->GetAnimManager()->GetAnimationBlock(strInternalBlockName);
+            if (pInternalBlock)
+            {
+                if (eRestoreType == eRestoreAnimation::BLOCK)
+                {
+                    Ped.RestoreAnimations(*pInternalBlock);
+                    return true;
+                }
+                else
+                {
+                    CAnimBlendHierarchy* pInternalAnimHierarchy = g_pGame->GetAnimManager()->GetAnimation(strInternalAnimName, pInternalBlock);
+                    if (pInternalAnimHierarchy)
+                    {
+                        Ped.RestoreAnimation(pInternalAnimHierarchy);
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}

--- a/Client/mods/deathmatch/logic/CIFPEngine.h
+++ b/Client/mods/deathmatch/logic/CIFPEngine.h
@@ -1,0 +1,32 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/mods/deathmatch/logic/CIFPEngine.h
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#ifndef __CIFPENGINE_H
+#define __CIFPENGINE_H
+#pragma once
+
+class CIFPEngine
+{
+public:
+    enum eRestoreAnimation
+    {
+        SINGLE,
+        BLOCK,
+        ALL
+    };
+
+    static std::shared_ptr<CClientIFP> EngineLoadIFP(CResource* pResource, CClientManager* pManager, const SString& strPath, const SString& strBlockName);
+    static bool                        EngineReplaceAnimation(CClientEntity* pEntity, const SString& strInternalBlockName, const SString& strInternalAnimName,
+                                                              const SString& strCustomBlockName, const SString& strCustomAnimName);
+    static bool                        EngineRestoreAnimation(CClientEntity* pEntity, const SString& strInternalBlockName, const SString& strInternalAnimName,
+                                                              const eRestoreAnimation& eRestoreType);
+};
+
+#endif

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -63,6 +63,11 @@ CResource::CResource(unsigned short usNetID, const char* szResourceName, CClient
     m_pResourceTXDRoot = new CClientDummy(g_pClientGame->GetManager(), INVALID_ELEMENT_ID, "txdroot");
     m_pResourceTXDRoot->MakeSystemEntity();
 
+    // Create our IFP root element. We set its parent when we're loaded.
+    // Make it a system entity so nothing but us can delete it.
+    m_pResourceIFPRoot = new CClientDummy(g_pClientGame->GetManager(), INVALID_ELEMENT_ID, "ifproot");
+    m_pResourceIFPRoot->MakeSystemEntity();
+
     m_strResourceDirectoryPath = SString("%s/resources/%s", g_pClientGame->GetFileCacheRoot(), *m_strResourceName);
     m_strResourcePrivateDirectoryPath = PathJoin(CServerIdManager::GetSingleton()->GetConnectionPrivateDirectory(), m_strResourceName);
 
@@ -99,6 +104,10 @@ CResource::~CResource(void)
     // Destroy the txd root so all dff elements are deleted except those moved out
     g_pClientGame->GetElementDeleter()->DeleteRecursive(m_pResourceTXDRoot);
     m_pResourceTXDRoot = NULL;
+
+    // Destroy the ifp root so all ifp elements are deleted except those moved out
+    g_pClientGame->GetElementDeleter()->DeleteRecursive(m_pResourceIFPRoot);
+    m_pResourceIFPRoot = NULL;
 
     // Destroy the ddf root so all dff elements are deleted except those moved out
     g_pClientGame->GetElementDeleter()->DeleteRecursive(m_pResourceDFFEntity);

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -86,6 +86,7 @@ public:
     CClientEntity*       GetResourceCOLModelRoot(void) { return m_pResourceCOLRoot; };
     CClientEntity*       GetResourceDFFRoot(void) { return m_pResourceDFFEntity; };
     CClientEntity*       GetResourceTXDRoot(void) { return m_pResourceTXDRoot; };
+    CClientEntity*       GetResourceIFPRoot(void) { return m_pResourceIFPRoot; };
 
     // This is to delete all the elements created in this resource that are created locally in this client
     void DeleteClientChildren(void);
@@ -125,6 +126,7 @@ private:
     class CClientEntity* m_pResourceDFFEntity;
     class CClientEntity* m_pResourceGUIEntity;
     class CClientEntity* m_pResourceTXDRoot;
+    class CClientEntity* m_pResourceIFPRoot;
     unsigned short       m_usRemainingNoClientCacheScripts;
     bool                 m_bLoadAfterReceivingNoClientCacheScripts;
     SString              m_strMinServerReq;

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -164,8 +164,8 @@ public:
     static bool GivePedWeapon(CClientEntity& Entity, uchar ucWeaponID, ushort usWeaponAmmo, bool bSetAsCurrent);
     static bool SetPedRotation(CClientEntity& Entity, float fRotation, bool bNewWay);
     static bool SetPedCanBeKnockedOffBike(CClientEntity& Entity, bool bCanBeKnockedOffBike);
-    static bool SetPedAnimation(CClientEntity& Entity, const char* szBlockName, const char* szAnimName, int iTime, int iBlend, bool bLoop, bool bUpdatePosition,
-                                bool bInterruptable, bool bFreezeLastFrame);
+    static bool SetPedAnimation(CClientEntity& Entity, const SString& strBlockName, const char* szAnimName, int iTime, int iBlend, bool bLoop,
+                                bool bUpdatePosition, bool bInterruptable, bool bFreezeLastFrame);
     static bool SetPedAnimationProgress(CClientEntity& Entity, const SString& strAnimName, float fProgress);
     static bool SetPedMoveAnim(CClientEntity& Entity, unsigned int iMoveAnim);
     static bool AddPedClothes(CClientEntity& Entity, const char* szTexture, const char* szModel, unsigned char ucType);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -16,11 +16,14 @@ void CLuaEngineDefs::LoadFunctions(void)
     CLuaCFunctions::AddFunction("engineLoadTXD", EngineLoadTXD);
     CLuaCFunctions::AddFunction("engineLoadCOL", EngineLoadCOL);
     CLuaCFunctions::AddFunction("engineLoadDFF", EngineLoadDFF);
+    CLuaCFunctions::AddFunction("engineLoadIFP", EngineLoadIFP);
     CLuaCFunctions::AddFunction("engineImportTXD", EngineImportTXD);
     CLuaCFunctions::AddFunction("engineReplaceCOL", EngineReplaceCOL);
     CLuaCFunctions::AddFunction("engineRestoreCOL", EngineRestoreCOL);
     CLuaCFunctions::AddFunction("engineReplaceModel", EngineReplaceModel);
     CLuaCFunctions::AddFunction("engineRestoreModel", EngineRestoreModel);
+    CLuaCFunctions::AddFunction("engineReplaceAnimation", EngineReplaceAnimation);
+    CLuaCFunctions::AddFunction("engineRestoreAnimation", EngineRestoreAnimation);
     CLuaCFunctions::AddFunction("engineGetModelLODDistance", EngineGetModelLODDistance);
     CLuaCFunctions::AddFunction("engineSetModelLODDistance", EngineSetModelLODDistance);
     CLuaCFunctions::AddFunction("engineSetAsynchronousLoading", EngineSetAsynchronousLoading);
@@ -274,6 +277,53 @@ int CLuaEngineDefs::EngineLoadTXD(lua_State* luaVM)
     return 1;
 }
 
+int CLuaEngineDefs::EngineLoadIFP(lua_State* luaVM)
+{
+    SString strFile = "";
+    SString strBlockName = "";
+
+    CScriptArgReader argStream(luaVM);
+    // Grab the IFP filename or data
+    argStream.ReadString(strFile);
+    argStream.ReadString(strBlockName);
+
+    if (!argStream.HasErrors())
+    {
+        // Grab our virtual machine and grab our resource from that.
+        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+        if (pLuaMain)
+        {
+            // Grab this resource
+            CResource* pResource = pLuaMain->GetResource();
+            if (pResource)
+            {
+                SString strPath;
+                // Is this a legal filepath?
+                if (CResourceManager::ParseResourcePathInput(strFile, pResource, &strPath))
+                {
+                    std::shared_ptr<CClientIFP> pIFP = CIFPEngine::EngineLoadIFP(pResource, m_pManager, strPath, strBlockName);
+                    if (pIFP != nullptr)
+                    {
+                        // Return the IFP element
+                        lua_pushelement(luaVM, pIFP.get());
+                        return 1;
+                    }
+                    else
+                        argStream.SetCustomError(strFile, "Error loading IFP");
+                }
+                else
+                    argStream.SetCustomError(strFile, "Bad file path");
+            }
+        }
+    }
+    if (argStream.HasErrors())
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // We failed
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaEngineDefs::EngineReplaceCOL(lua_State* luaVM)
 {
     CClientColModel* pCol = NULL;
@@ -422,6 +472,77 @@ int CLuaEngineDefs::EngineRestoreModel(lua_State* luaVM)
     }
 
     // Failure
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaEngineDefs::EngineReplaceAnimation(lua_State* luaVM)
+{
+    CClientEntity* pEntity = nullptr;
+    SString        strInternalBlockName = "";
+    SString        strInternalAnimName = "";
+    SString        strCustomBlockName = "";
+    SString        strCustomAnimName = "";
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pEntity);
+    argStream.ReadString(strInternalBlockName);
+    argStream.ReadString(strInternalAnimName);
+    argStream.ReadString(strCustomBlockName);
+    argStream.ReadString(strCustomAnimName);
+
+    if (!argStream.HasErrors())
+    {
+        if (CIFPEngine::EngineReplaceAnimation(pEntity, strInternalBlockName, strInternalAnimName, strCustomBlockName, strCustomAnimName))
+        {
+            lua_pushboolean(luaVM, true);
+            return 1;
+        }
+    }
+    if (argStream.HasErrors())
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaEngineDefs::EngineRestoreAnimation(lua_State* luaVM)
+{
+    CClientEntity*                pEntity = nullptr;
+    CIFPEngine::eRestoreAnimation eRestoreType = CIFPEngine::eRestoreAnimation::SINGLE;
+    SString                       strInternalBlockName = "";
+    SString                       strInternalAnimName = "";
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pEntity);
+    if (argStream.NextIsNil() || argStream.NextIsNone())
+    {
+        eRestoreType = CIFPEngine::eRestoreAnimation::ALL;
+    }
+    else
+    {
+        argStream.ReadString(strInternalBlockName);
+        if (argStream.NextIsNil() || argStream.NextIsNone())
+        {
+            eRestoreType = CIFPEngine::eRestoreAnimation::BLOCK;
+        }
+        else
+        {
+            argStream.ReadString(strInternalAnimName);
+        }
+    }
+
+    if (!argStream.HasErrors())
+    {
+        if (CIFPEngine::EngineRestoreAnimation(pEntity, strInternalBlockName, strInternalAnimName, eRestoreType))
+        {
+            lua_pushboolean(luaVM, true);
+            return 1;
+        }
+    }
+    if (argStream.HasErrors())
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
     lua_pushboolean(luaVM, false);
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -21,11 +21,14 @@ public:
     LUA_DECLARE(EngineLoadDFF);
     LUA_DECLARE(EngineLoadTXD);
     LUA_DECLARE(EngineLoadCOL);
+    LUA_DECLARE(EngineLoadIFP);
     LUA_DECLARE(EngineImportTXD);
     LUA_DECLARE(EngineReplaceCOL);
     LUA_DECLARE(EngineRestoreCOL);
     LUA_DECLARE(EngineReplaceModel);
     LUA_DECLARE(EngineRestoreModel);
+    LUA_DECLARE(EngineReplaceAnimation);
+    LUA_DECLARE(EngineRestoreAnimation);
     LUA_DECLARE(EngineReplaceMatchingAtomics);
     LUA_DECLARE(EngineReplaceWheelAtomics);
     LUA_DECLARE(EnginePositionAtomic);

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -17,6 +17,7 @@
 #include "..\game_sa\CBuildingSA.h"
 #include "..\game_sa\CPedSA.h"
 #include "..\game_sa\common.h"
+
 extern CCoreInterface* g_pCore;
 extern CMultiplayerSA* pMultiplayer;
 
@@ -147,10 +148,11 @@ DWORD RETURN_CPlantMgr_Render_fail = 0x5DBDAA;
 #define HOOKPOS_CEventHandler_ComputeKnockOffBikeResponse   0x4BA06F
 DWORD RETURN_CEventHandler_ComputeKnockOffBikeResponse = 0x4BA076;
 
+#define HOOKPOS_CAnimBlendAssoc_destructor                  0x4CECF0
+#define HOOKPOS_CAnimBlendAssocGroup_CopyAnimation          0x4CE14C
 #define HOOKPOS_CAnimManager_AddAnimation                   0x4d3aa0
-DWORD RETURN_CAnimManager_AddAnimation = 0x4D3AAA;
-#define HOOKPOS_CAnimManager_BlendAnimation                 0x4D4610
-DWORD RETURN_CAnimManager_BlendAnimation = 0x4D4617;
+#define HOOKPOS_CAnimManager_AddAnimationAndSync            0x4D3B30
+#define HOOKPOS_CAnimManager_BlendAnimation_Hierarchy       0x4D453E
 
 #define HOOKPOS_CPed_GetWeaponSkill                         0x5e3b60
 DWORD RETURN_CPed_GetWeaponSkill = 0x5E3B68;
@@ -349,8 +351,6 @@ PostWorldProcessHandler*    m_pPostWorldProcessHandler = NULL;
 IdleHandler*                m_pIdleHandler = NULL;
 PreFxRenderHandler*         m_pPreFxRenderHandler = NULL;
 PreHudRenderHandler*        m_pPreHudRenderHandler = NULL;
-AddAnimationHandler*        m_pAddAnimationHandler = NULL;
-BlendAnimationHandler*      m_pBlendAnimationHandler = NULL;
 ProcessCollisionHandler*    m_pProcessCollisionHandler = NULL;
 VehicleCollisionHandler*    m_pVehicleCollisionHandler = NULL;
 HeliKillHandler*            m_pHeliKillHandler = NULL;
@@ -412,8 +412,12 @@ void HOOK_RenderScene_Plants();
 void HOOK_RenderScene_end();
 void HOOK_CPlantMgr_Render();
 void HOOK_CEventHandler_ComputeKnockOffBikeResponse();
+void HOOK_CAnimBlendAssoc_Hierarchy_Constructor();
+void HOOK_CAnimBlendAssoc_destructor();
 void HOOK_CAnimManager_AddAnimation();
-void HOOK_CAnimManager_BlendAnimation();
+void HOOK_CAnimManager_AddAnimationAndSync();
+void HOOK_CAnimBlendAssocGroup_CopyAnimation();
+void HOOK_CAnimManager_BlendAnimation_Hierarchy();
 void HOOK_CPed_GetWeaponSkill();
 void HOOK_CPed_AddGogglesModel();
 void HOOK_CPhysical_ProcessCollisionSectorList();
@@ -627,8 +631,11 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CGame_Process, (DWORD)HOOK_CGame_Process, 10);
     HookInstall(HOOKPOS_Idle, (DWORD)HOOK_Idle, 10);
     HookInstall(HOOKPOS_CEventHandler_ComputeKnockOffBikeResponse, (DWORD)HOOK_CEventHandler_ComputeKnockOffBikeResponse, 7);
+    HookInstall(HOOKPOS_CAnimBlendAssoc_destructor, (DWORD)HOOK_CAnimBlendAssoc_destructor, 6);
     HookInstall(HOOKPOS_CAnimManager_AddAnimation, (DWORD)HOOK_CAnimManager_AddAnimation, 10);
-    HookInstall(HOOKPOS_CAnimManager_BlendAnimation, (DWORD)HOOK_CAnimManager_BlendAnimation, 7);
+    HookInstall(HOOKPOS_CAnimManager_AddAnimationAndSync, (DWORD)HOOK_CAnimManager_AddAnimationAndSync, 10);
+    HookInstall(HOOKPOS_CAnimBlendAssocGroup_CopyAnimation, (DWORD)HOOK_CAnimBlendAssocGroup_CopyAnimation, 5);
+    HookInstall(HOOKPOS_CAnimManager_BlendAnimation_Hierarchy, (DWORD)HOOK_CAnimManager_BlendAnimation_Hierarchy, 5);
     HookInstall(HOOKPOS_CPed_GetWeaponSkill, (DWORD)HOOK_CPed_GetWeaponSkill, 8);
     HookInstall(HOOKPOS_CPed_AddGogglesModel, (DWORD)HOOK_CPed_AddGogglesModel, 6);
     HookInstall(HOOKPOS_CPhysical_ProcessCollisionSectorList, (DWORD)HOOK_CPhysical_ProcessCollisionSectorList, 7);
@@ -2184,16 +2191,6 @@ void CMultiplayerSA::SetPreHudRenderHandler(PreHudRenderHandler* pHandler)
     m_pPreHudRenderHandler = pHandler;
 }
 
-void CMultiplayerSA::SetAddAnimationHandler(AddAnimationHandler* pHandler)
-{
-    m_pAddAnimationHandler = pHandler;
-}
-
-void CMultiplayerSA::SetBlendAnimationHandler(BlendAnimationHandler* pHandler)
-{
-    m_pBlendAnimationHandler = pHandler;
-}
-
 void CMultiplayerSA::SetProcessCollisionHandler(ProcessCollisionHandler* pHandler)
 {
     m_pProcessCollisionHandler = pHandler;
@@ -2881,11 +2878,11 @@ void _declspec(naked) HOOK_FxManager_CreateFxSystem()
         // Restore the registers
         popad
 
-            // Put the new vector back onto the stack
+        // Put the new vector back onto the stack
         mov         eax, pNewCreateFxSystem_Matrix
         mov         [esp+12], eax
 
-            // The original code we replaced
+        // The original code we replaced
         mov         eax, [esp+16]
         mov         edx, [esp+8]
 
@@ -2920,7 +2917,7 @@ void _declspec(naked) HOOK_FxManager_DestroyFxSystem()
         // Restore the registers
         popad
 
-            // The original code we replaced
+        // The original code we replaced
         push        ecx
         push        ebx
         push        edi
@@ -5235,66 +5232,6 @@ void _declspec(naked) HOOK_CEventHandler_ComputeKnockOffBikeResponse()
         popad
         call    dw_CEventDamage_AffectsPed
         jmp     RETURN_CEventHandler_ComputeKnockOffBikeResponse
-    }
-}
-
-RpClump*     animationClump = NULL;
-AssocGroupId animationGroup = 0;
-AnimationId  animationID = 0;
-void _declspec(naked) HOOK_CAnimManager_AddAnimation()
-{
-    _asm
-    {
-        mov     eax, [esp+4]
-        mov     animationClump, eax
-        mov     eax, [esp+8]
-        mov     animationGroup, eax
-        mov     eax, [esp+12]
-        mov     animationID, eax
-        pushad
-    }
-
-    if (m_pAddAnimationHandler)
-    {
-        m_pAddAnimationHandler(animationClump, animationGroup, animationID);
-    }
-
-    _asm
-    {
-        popad
-        mov     eax,dword ptr [esp+0Ch]
-        mov     edx,dword ptr ds:[0B4EA34h]
-        jmp     RETURN_CAnimManager_AddAnimation
-    }
-}
-
-float animationBlendDelta;
-void _declspec(naked) HOOK_CAnimManager_BlendAnimation()
-{
-    _asm
-    {
-        mov     eax, [esp+4]
-        mov     animationClump, eax
-        mov     eax, [esp+8]
-        mov     animationGroup, eax
-        mov     eax, [esp+12]
-        mov     animationID, eax
-        mov     eax, [esp+16]
-        mov     animationBlendDelta, eax
-        pushad
-    }
-
-    if (m_pBlendAnimationHandler)
-    {
-        m_pBlendAnimationHandler(animationClump, animationGroup, animationID, animationBlendDelta);
-    }
-
-    _asm
-    {
-        popad
-        sub     esp,14h
-        mov     ecx,dword ptr [esp+18h]
-        jmp     RETURN_CAnimManager_BlendAnimation
     }
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -20,6 +20,7 @@
 #include "CLimitsSA.h"
 
 #include "CRemoteDataSA.h"
+
 class CRemoteDataSA;
 #define DEFAULT_NEAR_CLIP_DISTANCE  ( 0.3f )
 
@@ -38,6 +39,13 @@ enum eRadioStationID
     Master_Sounds,
     WCTR,
 };
+
+typedef void(__thiscall* hCAnimBlendStaticAssociation_FreeSequenceArray)(CAnimBlendStaticAssociationSAInterface* pThis);
+typedef void(__cdecl* hUncompressAnimation)(CAnimBlendHierarchySAInterface* pAnimBlendHierarchyInterface);
+typedef void*(__cdecl* hCAnimBlendAssociation_NewOperator)(size_t iSizeInBytes);
+
+typedef CAnimBlendAssociationSAInterface*(__thiscall* hCAnimBlendAssociation_Constructor_staticAssocByReference)(
+    CAnimBlendAssociationSAInterface* pThis, CAnimBlendStaticAssociationSAInterface& StaticAssociationByReference);
 
 class CMultiplayerSA : public CMultiplayer
 {
@@ -106,8 +114,11 @@ public:
     void SetIdleHandler(IdleHandler* pHandler);
     void SetPreFxRenderHandler(PreFxRenderHandler* pHandler);
     void SetPreHudRenderHandler(PreHudRenderHandler* pHandler);
+    void SetCAnimBlendAssocDestructorHandler(CAnimBlendAssocDestructorHandler* pHandler);
     void SetAddAnimationHandler(AddAnimationHandler* pHandler);
-    void SetBlendAnimationHandler(BlendAnimationHandler* pHandler);
+    void SetAddAnimationAndSyncHandler(AddAnimationAndSyncHandler* pHandler);
+    void SetAssocGroupCopyAnimationHandler(AssocGroupCopyAnimationHandler* pHandler);
+    void SetBlendAnimationHierarchyHandler(BlendAnimationHierarchyHandler* pHandler);
     void SetProcessCollisionHandler(ProcessCollisionHandler* pHandler);
     void SetVehicleCollisionHandler(VehicleCollisionHandler* pHandler);
     void SetVehicleDamageHandler(VehicleDamageHandler* pHandler);

--- a/Client/multiplayer_sa/CMultiplayerSA_CustomAnimations.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_CustomAnimations.cpp
@@ -1,0 +1,297 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Client/multiplayer_sa/CMultiplayerSA_CustomAnimations.cpp
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+
+#include <../game_sa/CAnimBlendHierarchySA.h>
+#include <../game_sa/CAnimBlendStaticAssociationSA.h>
+#include <../game_sa/CAnimBlendAssociationSA.h>
+#include <../game_sa/CAnimBlendAssocGroupSA.h>
+
+DWORD FUNC_CAnimBlendAssociation__ReferenceAnimBlock = 0x4CEA50;
+DWORD FUNC_UncompressAnimation = 0x4D41C0;
+DWORD FUNC_CAnimBlendAssociation__CAnimBlendAssociation_hierarchy = 0x4CEFC0;
+
+DWORD RETURN_CAnimBlendAssocGroup_CopyAnimation_NORMALFLOW = 0x4CE151;
+DWORD RETURN_CAnimBlendAssocGroup_CopyAnimation = 0x4CE187;
+DWORD RETURN_CAnimBlendAssocGroup_CopyAnimation_ERROR = 0x4CE199;
+DWORD RETURN_CAnimManager_AddAnimation = 0x4D3AB1;
+DWORD RETURN_CAnimManager_AddAnimationAndSync = 0x4D3B41;
+DWORD RETURN_CAnimManager_BlendAnimation_Hierarchy = 0x4D4577;
+
+auto CAnimBlendStaticAssociation_FreeSequenceArray = (hCAnimBlendStaticAssociation_FreeSequenceArray)0x4ce9a0;
+auto UncompressAnimation = (hUncompressAnimation)0x4d41c0;
+auto CAnimBlendAssociation_Constructor_staticAssocByReference = (hCAnimBlendAssociation_Constructor_staticAssocByReference)0x4CF080;
+
+auto CAnimBlendAssociation_NewOperator_US = (hCAnimBlendAssociation_NewOperator)0x82119A;
+auto CAnimBlendAssociation_NewOperator_EU = (hCAnimBlendAssociation_NewOperator)0x8211DA;
+
+AddAnimationHandler*            m_pAddAnimationHandler = nullptr;
+AddAnimationAndSyncHandler*     m_pAddAnimationAndSyncHandler = nullptr;
+AssocGroupCopyAnimationHandler* m_pAssocGroupCopyAnimationHandler = nullptr;
+BlendAnimationHierarchyHandler* m_pBlendAnimationHierarchyHandler = nullptr;
+
+int _cdecl OnCAnimBlendAssocGroupCopyAnimation(AssocGroupId animGroup, int iAnimId);
+
+void CMultiplayerSA::SetAddAnimationHandler(AddAnimationHandler* pHandler)
+{
+    m_pAddAnimationHandler = pHandler;
+}
+
+void CMultiplayerSA::SetAddAnimationAndSyncHandler(AddAnimationAndSyncHandler* pHandler)
+{
+    m_pAddAnimationAndSyncHandler = pHandler;
+}
+
+void CMultiplayerSA::SetAssocGroupCopyAnimationHandler(AssocGroupCopyAnimationHandler* pHandler)
+{
+    m_pAssocGroupCopyAnimationHandler = pHandler;
+}
+
+void CMultiplayerSA::SetBlendAnimationHierarchyHandler(BlendAnimationHierarchyHandler* pHandler)
+{
+    m_pBlendAnimationHierarchyHandler = pHandler;
+}
+
+CAnimBlendAssociationSAInterface* __cdecl CAnimBlendAssocGroup_CopyAnimation(RpClump* pClump, CAnimBlendAssocGroupSAInterface* pAnimAssocGroupInterface,
+                                                                             AnimationId animID)
+{
+    auto CAnimBlendAssociation_NewOperator = pGameInterface->GetGameVersion() == VERSION_EU_10 ? CAnimBlendAssociation_NewOperator_EU : CAnimBlendAssociation_NewOperator_US;
+    auto pAnimAssociationInterface =
+        reinterpret_cast<CAnimBlendAssociationSAInterface*>(CAnimBlendAssociation_NewOperator(sizeof(CAnimBlendAssociationSAInterface)));
+
+    if (pAnimAssociationInterface)
+    {
+        CAnimBlendStaticAssociationSAInterface staticAnimAssociationInterface;
+
+        m_pAssocGroupCopyAnimationHandler(&staticAnimAssociationInterface, pAnimAssociationInterface, pClump, pAnimAssocGroupInterface, animID);
+
+        UncompressAnimation(staticAnimAssociationInterface.pAnimHeirarchy);
+
+        CAnimBlendAssociation_Constructor_staticAssocByReference(pAnimAssociationInterface, staticAnimAssociationInterface);
+
+        CAnimBlendStaticAssociation_FreeSequenceArray(&staticAnimAssociationInterface);
+    }
+    return pAnimAssociationInterface;
+}
+
+void _declspec(naked) HOOK_CAnimBlendAssocGroup_CopyAnimation()
+{
+    _asm
+    {
+        pushad
+    }
+
+    if (m_pAssocGroupCopyAnimationHandler)
+    {
+        _asm
+        {
+            popad
+
+            push    esi
+
+            push    eax // animID
+            push    ecx // pAnimAssocGroupInterface
+            push    edi // pClump
+            call    CAnimBlendAssocGroup_CopyAnimation
+            add     esp, 0Ch
+
+            test    eax, eax
+            jz      ERROR_CopyAnimation
+
+            jmp     RETURN_CAnimBlendAssocGroup_CopyAnimation
+
+            ERROR_CopyAnimation:
+            jmp        RETURN_CAnimBlendAssocGroup_CopyAnimation_ERROR
+        }
+    }
+
+    _asm
+    {
+        popad
+        mov     ecx, [ecx+4]
+        sub     eax, edx
+        jmp RETURN_CAnimBlendAssocGroup_CopyAnimation_NORMALFLOW
+    }
+}
+
+void _declspec(naked) HOOK_CAnimManager_AddAnimation()
+{
+    _asm
+    {
+        pushad
+    }
+
+    if (m_pAddAnimationHandler)
+    {
+        _asm
+        {
+            popad
+            mov     ecx, [esp+4]  // animationClump
+            mov     edx, [esp+8]  // animationGroup
+            mov     eax, [esp+12] // animationID
+            push    eax
+            push    edx
+            call    OnCAnimBlendAssocGroupCopyAnimation
+            add     esp, 8
+            mov     [esp+12], eax // replace animationID
+
+            // call our handler function
+            push    eax
+            push    edx
+            mov     ecx, [esp+12] // animationClump
+            push    ecx
+            call    m_pAddAnimationHandler
+            add     esp, 0Ch
+            pushad
+            jmp     NORMAL_FLOW_AddAnimation
+        }
+    }
+
+    _asm
+    {
+        NORMAL_FLOW_AddAnimation:
+        popad
+        mov     eax, dword ptr [esp+0Ch]
+        mov     edx, dword ptr ds:[0B4EA34h]
+        push    esi
+        push    edi
+        push    eax
+        mov     eax, dword ptr [esp+14h] // animationGroup
+        mov     edi, dword ptr [esp+10h] // animationClump
+        jmp     RETURN_CAnimManager_AddAnimation
+    }
+}
+
+void _declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
+{
+    _asm
+    {
+        pushad
+    }
+
+    if (m_pAddAnimationAndSyncHandler)
+    {
+         _asm
+        {
+            popad
+            mov     ecx, [esp+4]  // animationClump
+            mov     ebx, [esp+8]  // pAnimAssociationToSyncWith
+            mov     edx, [esp+12] // animationGroup
+            mov     eax, [esp+16] // animationID
+            push    eax
+            push    edx
+            call    OnCAnimBlendAssocGroupCopyAnimation
+            add     esp, 8
+            mov     [esp+16], eax // replace animationID
+
+            // call our handler function
+            push    eax
+            push    edx
+            push    ebx
+            mov     ecx, [esp+16] // animationClump
+            push    ecx
+            call    m_pAddAnimationAndSyncHandler
+            add     esp, 10h
+            pushad
+            jmp     NORMAL_FLOW_AddAnimationAndSync
+        }
+    }
+
+    _asm
+    {
+        NORMAL_FLOW_AddAnimationAndSync:
+        popad
+        mov     eax, dword ptr [esp+10h]
+        mov     edx, dword ptr ds:[0B4EA34h]
+        push    esi
+        push    edi
+        push    eax
+        mov     eax, dword ptr [esp+18h] // animationGroup
+        mov     edi, dword ptr [esp+10h] // animationClump
+        jmp     RETURN_CAnimManager_AddAnimationAndSync
+    }
+}
+
+void _declspec(naked) HOOK_CAnimManager_BlendAnimation_Hierarchy()
+{
+    _asm
+    {
+        pushad
+    }
+
+    if (m_pBlendAnimationHierarchyHandler)
+    {
+        _asm
+        {
+            popad
+            push    eax // pAnimAssociation
+            push    ecx // pAnimHierarchy
+
+            push    ebp
+            mov     ebp, esp
+            sub     esp, 8
+
+            // call our handler function
+            mov     edx, [ebp+28h+4+12]
+            lea     ecx, [ebp+28h+4+20]
+            push    edx  // pClump
+            push    ecx  // pFlags
+            lea     edx, [ebp-4]
+            push    edx  //  CAnimBlendHierarchySAInterface ** pOutAnimHierarchy
+            mov     edx, [esp+28]
+            push    edx  // pAnimAssociation
+            call    m_pBlendAnimationHierarchyHandler //CAnimManager_BlendAnimation_Hierarchy
+            add     esp, 10h
+
+            mov     ecx, [ebp-4] // pCustomAnimHierarchy
+
+            add     esp, 8 // remove space for local var
+            mov     esp, ebp
+            pop     ebp
+
+             // Check if it's a custom animation or not
+            cmp     al, 00
+            je      NOT_CUSTOM_ANIMATION_CAnimManager_BlendAnimation_Hierarchy
+
+            // Replace animation hierarchy with our custom one
+            mov     [esp], ecx
+            mov     [esp+28h+8+8], ecx
+
+            NOT_CUSTOM_ANIMATION_CAnimManager_BlendAnimation_Hierarchy:
+            pop ecx
+            pop eax
+            pushad
+            jmp NORMAL_FLOW_BlendAnimation_Hierarchy
+        }
+    }
+
+    _asm
+    {
+        NORMAL_FLOW_BlendAnimation_Hierarchy:
+        popad
+        mov     edx, [esp+28h+4]
+        push    ecx      // pAnimHierarchy
+        push    edx      // pClump
+        mov     ecx, eax // pAnimAssociation
+        call    FUNC_CAnimBlendAssociation__CAnimBlendAssociation_hierarchy
+        mov     esi, eax
+        mov     ax, word ptr [esp+28h+0Ch] // flags
+        mov     ecx, esi
+        mov     [esp+28h-4], 0FFFFFFFFh // var_4
+        mov     [esp+28h-18h], esi
+        mov     [esi+2Eh], ax
+        call    FUNC_CAnimBlendAssociation__ReferenceAnimBlock
+        mov     ecx, [esp+28h+8] // pAnimHierarchy
+        push    ecx
+        call    FUNC_UncompressAnimation
+        jmp    RETURN_CAnimManager_BlendAnimation_Hierarchy
+    }
+}

--- a/Client/multiplayer_sa/CMultiplayerSA_FixBadAnimId.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FixBadAnimId.cpp
@@ -12,10 +12,18 @@
 #include "StdInc.h"
 #include "../game_sa/CAnimBlendAssocGroupSA.h"
 
+constexpr CAnimBlendAssocGroupSAInterface* getAnimAssocGroupInterface(AssocGroupId animGroup)
+{
+    DWORD* pAnimAssocGroupsArray = reinterpret_cast<DWORD*>(*(DWORD*)0xb4ea34);
+    return reinterpret_cast<CAnimBlendAssocGroupSAInterface*>(pAnimAssocGroupsArray + 5 * animGroup);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////
 // Check for anims that will crash and change to one that wont. (The new anim will be wrong and look crap though)
-int _cdecl OnCAnimBlendAssocGroupCopyAnimation(CAnimBlendAssocGroupSAInterface* pGroup, int iAnimId)
+int _cdecl OnCAnimBlendAssocGroupCopyAnimation(AssocGroupId animGroup, int iAnimId)
 {
+    auto pGroup = getAnimAssocGroupInterface(animGroup);
+
     // Apply offset
     int iUseAnimId = iAnimId - pGroup->iIDOffset;
 
@@ -111,6 +119,5 @@ void _declspec(naked) HOOK_GetAnimHierarchyFromSkinClump()
 //////////////////////////////////////////////////////////////////////////////////////////
 void CMultiplayerSA::InitHooks_FixBadAnimId(void)
 {
-    EZHookInstall(CAnimBlendAssocGroupCopyAnimation);
     EZHookInstall(GetAnimHierarchyFromSkinClump);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_HookDestructors.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_HookDestructors.cpp
@@ -13,11 +13,12 @@
 
 namespace
 {
-    GameObjectDestructHandler*     pGameObjectDestructHandler = NULL;
-    GameVehicleDestructHandler*    pGameVehicleDestructHandler = NULL;
-    GamePlayerDestructHandler*     pGamePlayerDestructHandler = NULL;
-    GameProjectileDestructHandler* pGameProjectileDestructHandler = NULL;
-    GameModelRemoveHandler*        pGameModelRemoveHandler = NULL;
+    CAnimBlendAssocDestructorHandler* m_pCAnimBlendAssocDestructorHandler = nullptr;
+    GameObjectDestructHandler*        pGameObjectDestructHandler = NULL;
+    GameVehicleDestructHandler*       pGameVehicleDestructHandler = NULL;
+    GamePlayerDestructHandler*        pGamePlayerDestructHandler = NULL;
+    GameProjectileDestructHandler*    pGameProjectileDestructHandler = NULL;
+    GameModelRemoveHandler*           pGameModelRemoveHandler = NULL;
 
     #define FUNC_CPtrListSingleLink_Remove  0x0533610
     #define FUNC_CPtrListDoubleLink_Remove  0x05336B0
@@ -140,6 +141,34 @@ namespace
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 //
+void __cdecl CAnimBlendAssoc_destructor(CAnimBlendAssociationSAInterface* pThis)
+{
+    if (m_pCAnimBlendAssocDestructorHandler)
+    {
+        m_pCAnimBlendAssocDestructorHandler(pThis);
+    }
+}
+
+DWORD RETURN_CAnimBlendAssoc_destructor = 0x4CECF6;
+void _declspec(naked) HOOK_CAnimBlendAssoc_destructor()
+{
+    _asm
+    {
+        push    ecx
+
+        push    ecx
+        call    CAnimBlendAssoc_destructor
+        add     esp, 0x4
+
+        pop     ecx
+
+        push    esi
+        mov     esi, ecx
+        mov     eax, [esi + 10h]
+        jmp     RETURN_CAnimBlendAssoc_destructor
+    }
+}
+
 void _cdecl OnCObjectDestructor(DWORD calledFrom, CObjectSAInterface* pObject)
 {
     // Tell client to check for things going away
@@ -489,6 +518,11 @@ void _declspec(naked) HOOK_CStreamingRemoveModel()
 // Set handlers
 //
 //////////////////////////////////////////////////////////////////////////////////////////
+void CMultiplayerSA::SetCAnimBlendAssocDestructorHandler(CAnimBlendAssocDestructorHandler* pHandler)
+{
+    m_pCAnimBlendAssocDestructorHandler = pHandler;
+}
+
 void CMultiplayerSA::SetGameObjectDestructHandler(GameObjectDestructHandler* pHandler)
 {
     pGameObjectDestructHandler = pHandler;

--- a/Client/sdk/game/CAnimBlendAssocGroup.h
+++ b/Client/sdk/game/CAnimBlendAssocGroup.h
@@ -14,6 +14,7 @@
 
 typedef unsigned char BYTE;
 typedef unsigned long AssocGroupId;
+class CAnimBlendAssociation;
 class CAnimBlendStaticAssociation;
 struct RpClump;
 class CAnimBlock;
@@ -21,14 +22,16 @@ class CAnimBlock;
 class CAnimBlendAssocGroup
 {
 public:
-    virtual void                         InitEmptyAssociations(RpClump* pClump) = 0;
-    virtual bool                         IsCreated(void) = 0;
-    virtual int                          GetNumAnimations(void) = 0;
-    virtual CAnimBlock*                  GetAnimBlock(void) = 0;
-    virtual CAnimBlendStaticAssociation* GetAnimation(unsigned int ID) = 0;
-    virtual void                         CreateAssociations(const char* szBlockName) = 0;
-    virtual bool                         IsLoaded(void) = 0;
-    virtual void                         SetIDOffset(int iOffset) = 0;
+    virtual CAnimBlendAssociationSAInterface* CopyAnimation(unsigned int AnimID) = 0;
+    virtual void                              InitEmptyAssociations(RpClump* pClump) = 0;
+    virtual bool                              IsCreated(void) = 0;
+    virtual int                               GetNumAnimations(void) = 0;
+    virtual CAnimBlock*                       GetAnimBlock(void) = 0;
+    virtual CAnimBlendStaticAssociation*      GetAnimation(unsigned int ID) = 0;
+    virtual AssocGroupId                      GetGroupID(void) = 0;
+    virtual void                              CreateAssociations(const char* szBlockName) = 0;
+    virtual bool                              IsLoaded(void) = 0;
+    virtual void                              SetIDOffset(int iOffset) = 0;
 };
 
 #endif

--- a/Client/sdk/game/CAnimBlendHierarchy.h
+++ b/Client/sdk/game/CAnimBlendHierarchy.h
@@ -17,8 +17,22 @@ class CAnimBlendHierarchySAInterface;
 class CAnimBlendHierarchy
 {
 public:
-    virtual CAnimBlendHierarchySAInterface* GetInterface(void) = 0;
+    virtual void                            Initialize(void) = 0;
+    virtual void                            SetName(const char* szName) = 0;
+    virtual void                            SetSequences(CAnimBlendSequenceSAInterface* pSequences) = 0;
+    virtual void                            SetNumSequences(unsigned short uNumSequences) = 0;
+    virtual void                            SetRunningCompressed(bool bCompressed) = 0;
+    virtual void                            SetAnimationBlockID(int iBlockID) = 0;
+    virtual void                            RemoveAnimSequences(void) = 0;
+    virtual void                            RemoveFromUncompressedCache(void) = 0;
+    virtual void                            RemoveQuaternionFlips(void) = 0;
+    virtual void                            CalculateTotalTime(void) = 0;
+    virtual CAnimBlendSequenceSAInterface*  GetSequence(DWORD dwIndex) = 0;
+    virtual CAnimBlendSequenceSAInterface*  GetSequences(void) = 0;
+    virtual unsigned short                  GetNumSequences(void) = 0;
+    virtual bool                            isRunningCompressed(void) = 0;
     virtual int                             GetAnimBlockID(void) = 0;
+    virtual CAnimBlendHierarchySAInterface* GetInterface(void) = 0;
 };
 
 #endif

--- a/Client/sdk/game/CAnimBlendSequence.h
+++ b/Client/sdk/game/CAnimBlendSequence.h
@@ -15,6 +15,18 @@
 class CAnimBlendSequence
 {
 public:
+    virtual void                           Initialize(void) = 0;
+    virtual void                           SetName(const char* szName) = 0;
+    virtual void                           SetBoneTag(int32_t i32BoneID) = 0;
+    virtual void                           SetKeyFrames(size_t cKeyFrames, bool bRoot, bool bCompressed, void* pKeyFrames) = 0;
+    virtual void*                          GetKeyFrame(size_t iFrame, uint32_t u32FrameSizeInBytes) = 0;
+    virtual uint32_t                       GetHash(void) = 0;
+    virtual uint16_t                       GetBoneTag(void) = 0;
+    virtual BYTE*                          GetKeyFrames(void) = 0;
+    virtual unsigned short                 GetKeyFramesCount(void) = 0;
+    virtual bool                           IsBigChunkForAllSequences(void) = 0;
+    virtual void                           CopySequenceProperties(CAnimBlendSequenceSAInterface* pAnimSequenceInterface) = 0;
+    virtual CAnimBlendSequenceSAInterface* GetInterface(void) = 0;
 };
 
 #endif

--- a/Client/sdk/game/CAnimBlendStaticAssociation.h
+++ b/Client/sdk/game/CAnimBlendStaticAssociation.h
@@ -12,9 +12,23 @@
 #ifndef __CAnimBlendStaticAssociation_H
 #define __CAnimBlendStaticAssociation_H
 
+struct RpClump;
+class CAnimBlendHierarchySAInterface;
+
 class CAnimBlendStaticAssociation
 {
 public:
+    virtual void Initialize(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimBlendHierarchyInterface) = 0;
+    virtual void SetNumBlendNodes(unsigned short nNumBlendNodes) = 0;
+    virtual void SetAnimID(short sAnimID) = 0;
+    virtual void SetAnimGroup(short sAnimGroup) = 0;
+    virtual void SetFlags(short sFlags) = 0;
+
+    virtual unsigned short                  GetNumBlendNodes(void) = 0;
+    virtual short                           GetAnimID(void) = 0;
+    virtual short                           GetAnimGroup(void) = 0;
+    virtual short                           GetFlags(void) = 0;
+    virtual CAnimBlendHierarchySAInterface* GetAnimHierachyInterface(void) = 0;
 };
 
 #endif

--- a/Client/sdk/game/CAnimBlock.h
+++ b/Client/sdk/game/CAnimBlock.h
@@ -19,17 +19,21 @@ enum EModelRequestType
 };
 
 class CAnimBlockSAInterface;
+class CAnimBlendHierarchySAInterface;
 
 class CAnimBlock
 {
 public:
-    virtual CAnimBlockSAInterface* GetInterface(void) = 0;
-    virtual char*                  GetName(void) = 0;
-    virtual int                    GetIndex(void) = 0;
-    virtual void                   AddRef(void) = 0;
-    virtual unsigned short         GetRefs(void) = 0;
-    virtual void                   Request(EModelRequestType requestType, bool bAllowBlockingFail = false) = 0;
-    virtual bool                   IsLoaded(void) = 0;
+    virtual CAnimBlockSAInterface*          GetInterface(void) = 0;
+    virtual char*                           GetName(void) = 0;
+    virtual int                             GetIndex(void) = 0;
+    virtual void                            AddRef(void) = 0;
+    virtual unsigned short                  GetRefs(void) = 0;
+    virtual bool                            IsLoaded(void) = 0;
+    virtual int                             GetIDOffset(void) = 0;
+    virtual size_t                          GetAnimationCount(void) = 0;
+    virtual void                            Request(EModelRequestType requestType, bool bAllowBlockingFail = false) = 0;
+    virtual CAnimBlendHierarchySAInterface* GetAnimationHierarchyInterface(size_t iAnimation) = 0;
 };
 
 #endif

--- a/Client/sdk/game/CAnimManager.h
+++ b/Client/sdk/game/CAnimManager.h
@@ -12,6 +12,8 @@
 #ifndef __CAnimManager_H
 #define __CAnimManager_H
 
+#include <memory>
+
 // Get correct values
 #define MAX_ANIM_GROUPS 200
 #define MAX_ANIMATIONS 500
@@ -20,10 +22,15 @@
 typedef unsigned long AssocGroupId;
 typedef unsigned long AnimationId;
 
+class SString;
 class CAnimBlendAssocGroup;
 class CAnimBlendHierarchy;
+class CAnimBlendSequence;
 class CAnimBlock;
 class CAnimBlendAssociation;
+class CAnimBlendStaticAssociation;
+class CAnimBlendStaticAssociationSAInterface;
+class CClientPed;
 struct RpClump;
 struct RwStream;
 struct AnimAssocDefinition;
@@ -32,6 +39,7 @@ struct AnimDescriptor;
 class CAnimBlendAssocGroupSAInterface;
 class CAnimBlendAssociationSAInterface;
 class CAnimBlendHierarchySAInterface;
+class CAnimBlendSequenceSAInterface;
 class CAnimBlockSAInterface;
 
 class CAnimManager
@@ -39,6 +47,8 @@ class CAnimManager
     friend class CAnimBlendAssociation;
 
 public:
+    typedef std::unique_ptr<CAnimBlendStaticAssociation> StaticAssocIntface_type;
+
     virtual void Initialize(void) = 0;
     virtual void Shutdown(void) = 0;
 
@@ -61,14 +71,14 @@ public:
     virtual const char *GetAnimGroupName(AssocGroupId groupID) = 0;
     virtual const char *GetAnimBlockName(AssocGroupId groupID) = 0;
 
-    virtual CAnimBlendAssociation *CreateAnimAssociation(AssocGroupId animGroup, AnimationId animID) = 0;
-    virtual CAnimBlendAssociation *GetAnimAssociation(AssocGroupId animGroup, AnimationId animID) = 0;
-    virtual CAnimBlendAssociation *GetAnimAssociation(AssocGroupId animGroup, const char *szAnimName) = 0;
-    virtual CAnimBlendAssociation *AddAnimation(RpClump *pClump, AssocGroupId animGroup, AnimationId animID) = 0;
-    virtual CAnimBlendAssociation *AddAnimation(RpClump *pClump, CAnimBlendHierarchy *, int ID) = 0;
-    virtual CAnimBlendAssociation *AddAnimationAndSync(RpClump *pClump, CAnimBlendAssociation *pAssociation, AssocGroupId animGroup, AnimationId animID) = 0;
-    virtual CAnimBlendAssociation *BlendAnimation(RpClump *pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta) = 0;
-    virtual CAnimBlendAssociation *BlendAnimation(RpClump *pClump, CAnimBlendHierarchy *pHierarchy, int ID, float fBlendDelta) = 0;
+    virtual CAnimBlendAssociation * CreateAnimAssociation(AssocGroupId animGroup, AnimationId animID) = 0;
+    virtual StaticAssocIntface_type GetAnimStaticAssociation(AssocGroupId animGroup, AnimationId animID) = 0;
+    virtual CAnimBlendAssociation * GetAnimAssociation(AssocGroupId animGroup, const char *szAnimName) = 0;
+    virtual CAnimBlendAssociation * AddAnimation(RpClump *pClump, AssocGroupId animGroup, AnimationId animID) = 0;
+    virtual CAnimBlendAssociation * AddAnimation(RpClump *pClump, CAnimBlendHierarchy *, int ID) = 0;
+    virtual CAnimBlendAssociation * AddAnimationAndSync(RpClump *pClump, CAnimBlendAssociation *pAssociation, AssocGroupId animGroup, AnimationId animID) = 0;
+    virtual CAnimBlendAssociation * BlendAnimation(RpClump *pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta) = 0;
+    virtual CAnimBlendAssociation * BlendAnimation(RpClump *pClump, CAnimBlendHierarchy *pHierarchy, int ID, float fBlendDelta) = 0;
 
     virtual void AddAnimBlockRef(int ID) = 0;
     virtual void RemoveAnimBlockRef(int ID) = 0;
@@ -83,11 +93,14 @@ public:
 
     virtual void UncompressAnimation(CAnimBlendHierarchy *pHierarchy) = 0;
     virtual void RemoveFromUncompressedCache(CAnimBlendHierarchy *pHierarchy) = 0;
+    virtual void RemoveFromUncompressedCache(CAnimBlendHierarchySAInterface *pInterface) = 0;
 
-    virtual void LoadAnimFile(const char *szFile) = 0;
-    virtual void LoadAnimFile(RwStream *pStream, bool b1, const char *sz1) = 0;
-    virtual void LoadAnimFiles(void) = 0;
-    virtual void RemoveLastAnimFile(void) = 0;
+    virtual void  LoadAnimFile(const char *szFile) = 0;
+    virtual void  LoadAnimFile(RwStream *pStream, bool b1, const char *sz1) = 0;
+    virtual void  LoadAnimFiles(void) = 0;
+    virtual void  RemoveLastAnimFile(void) = 0;
+    virtual BYTE *AllocateKeyFramesMemory(uint32_t u32BytesToAllocate) = 0;
+    virtual void  FreeKeyFramesMemory(void *pKeyFrames) = 0;
 
     // Non members
     virtual bool                   HasAnimGroupLoaded(AssocGroupId groupID) = 0;
@@ -103,6 +116,20 @@ public:
     virtual CAnimBlendAssocGroup * GetAnimBlendAssocGroup(CAnimBlendAssocGroupSAInterface *pInterface) = 0;
     virtual CAnimBlock *           GetAnimBlock(CAnimBlockSAInterface *pInterface) = 0;
     virtual CAnimBlendHierarchy *  GetAnimBlendHierarchy(CAnimBlendHierarchySAInterface *pInterface) = 0;
+
+    virtual StaticAssocIntface_type GetAnimStaticAssociation(CAnimBlendStaticAssociationSAInterface *pInterface) = 0;
+
+    // MTA members, but use this strictly for custom animations only
+    virtual std::unique_ptr<CAnimBlendHierarchy> GetCustomAnimBlendHierarchy(CAnimBlendHierarchySAInterface *pInterface) = 0;
+    virtual std::unique_ptr<CAnimBlendSequence>  GetCustomAnimBlendSequence(CAnimBlendSequenceSAInterface *pInterface) = 0;
+    virtual std::unique_ptr<CAnimBlendHierarchy> GetCustomAnimBlendHierarchy(void) = 0;
+    virtual std::unique_ptr<CAnimBlendSequence>  GetCustomAnimBlendSequence(void) = 0;
+    virtual void                                 DeleteCustomAnimHierarchyInterface(CAnimBlendHierarchySAInterface *pInterface) = 0;
+    virtual void                                 DeleteCustomAnimSequenceInterface(CAnimBlendSequenceSAInterface *pInterface) = 0;
+
+    virtual bool           isGateWayAnimationHierarchy(CAnimBlendHierarchySAInterface *pInterface) = 0;
+    virtual const SString &GetGateWayBlockName(void) = 0;
+    virtual const SString &GetGateWayAnimationName(void) = 0;
 };
 
 #endif

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -116,6 +116,8 @@ struct SShaderReplacementStats
 
 class __declspec(novtable) CGame
 {
+    typedef std::unique_ptr<CAnimBlendAssocGroup> AssocGroup_type;
+
 public:
     virtual CPools*                   GetPools() = 0;
     virtual CPlayerInfo*              GetPlayerInfo() = 0;

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -19,6 +19,8 @@
 #include <game/CStats.h>
 #include "CPopulationMP.h"
 #include "CLimits.h"
+#include <../Client/game_sa/CAnimBlendAssociationSA.h>
+#include <../Client/game_sa/CAnimBlendStaticAssociationSA.h>
 
 struct SRwResourceStats
 {
@@ -36,6 +38,10 @@ struct SClothesCacheStats
     uint uiNumRemoved;
 };
 
+class CAnimBlendAssociationSAInterface;
+class CAnimBlendStaticAssociationSAInterface;
+class CAnimBlendAssocGroupSAInterface;
+class CIFPAnimations;
 typedef unsigned long AssocGroupId;
 typedef unsigned long AnimationId;
 
@@ -65,8 +71,14 @@ typedef void(PostWorldProcessHandler)(void);
 typedef void(IdleHandler)(void);
 typedef void(PreFxRenderHandler)(void);
 typedef void(PreHudRenderHandler)(void);
-typedef void(AddAnimationHandler)(RpClump* pClump, AssocGroupId animGroup, AnimationId animID);
-typedef void(BlendAnimationHandler)(RpClump* pClump, AssocGroupId animGroup, AnimationId animID, float fBlendDelta);
+typedef CAnimBlendAssociationSAInterface*(AddAnimationHandler)(RpClump* pClump, AssocGroupId animGroup, AnimationId animID);
+typedef CAnimBlendAssociationSAInterface*(AddAnimationAndSyncHandler)(RpClump* pClump, CAnimBlendAssociationSAInterface* pAnimAssocToSyncWith,
+                                                                      AssocGroupId animGroup, AnimationId animID);
+typedef void(CAnimBlendAssocDestructorHandler)(CAnimBlendAssociationSAInterface* pThis);
+typedef bool(AssocGroupCopyAnimationHandler)(CAnimBlendStaticAssociationSAInterface* pOutAnimStaticAssoc, CAnimBlendAssociationSAInterface* pAnimAssoc,
+                                             RpClump* pClump, CAnimBlendAssocGroupSAInterface* pAnimAssocGroup, AnimationId animID);
+typedef bool(BlendAnimationHierarchyHandler)(CAnimBlendAssociationSAInterface* pAnimAssoc, CAnimBlendHierarchySAInterface** pOutAnimHierarchy, int* pFlags,
+                                             RpClump* pClump);
 typedef bool(ProcessCollisionHandler)(class CEntitySAInterface* pThisInterface, class CEntitySAInterface* pOtherInterface);
 typedef bool(VehicleCollisionHandler)(class CVehicleSAInterface* pCollidingVehicle, class CEntitySAInterface* pCollidedVehicle, int iModelIndex,
                                       float fDamageImpulseMag, float fCollidingDamageImpulseMag, uint16 usPieceType, CVector vecCollisionPos,
@@ -181,8 +193,11 @@ public:
     virtual void SetIdleHandler(IdleHandler* pHandler) = 0;
     virtual void SetPreFxRenderHandler(PreFxRenderHandler* pHandler) = 0;
     virtual void SetPreHudRenderHandler(PreHudRenderHandler* pHandler) = 0;
+    virtual void SetCAnimBlendAssocDestructorHandler(CAnimBlendAssocDestructorHandler* pHandler) = 0;
     virtual void SetAddAnimationHandler(AddAnimationHandler* pHandler) = 0;
-    virtual void SetBlendAnimationHandler(BlendAnimationHandler* pHandler) = 0;
+    virtual void SetAddAnimationAndSyncHandler(AddAnimationAndSyncHandler* pHandler) = 0;
+    virtual void SetAssocGroupCopyAnimationHandler(AssocGroupCopyAnimationHandler* pHandler) = 0;
+    virtual void SetBlendAnimationHierarchyHandler(BlendAnimationHierarchyHandler* pHandler) = 0;
     virtual void SetProcessCollisionHandler(ProcessCollisionHandler* pHandler) = 0;
     virtual void SetVehicleCollisionHandler(VehicleCollisionHandler* pHandler) = 0;
     virtual void SetVehicleDamageHandler(VehicleDamageHandler* pHandler) = 0;


### PR DESCRIPTION
Squashed commit of the following:

commit ae72bbcdb2be8360bf705a00b259079c6f41dfe1
Author: Jusonex <jusonex96@gmail.com>
Date:   Sat Jun 16 20:28:58 2018 +0200

    Make custom animations work with the EU version too

commit 432344fafc821b93828eec5c6ea3acb2eb20cdb2
Author: Jusonex <jusonex96@gmail.com>
Date:   Sat Jun 16 17:28:56 2018 +0200

    Fix source formatting in CMultiplayerSA based on the clang-format change

commit 44e8167e15fecb32f098db1d4f337c7cb4a36a61
Merge: 9900349c5 05fbbfbfc
Author: Jusonex <jusonex96@gmail.com>
Date:   Sat Jun 16 17:28:33 2018 +0200

    Merge remote-tracking branch 'origin/master' into feature/custom-ifp-animations

commit 9900349c50ee9cfb9115e047cf58f0e3cd066625
Merge: d38e68ece 9f4d3de1e
Author: saml1er <10183157+saml1er@users.noreply.github.com>
Date:   Mon Jun 11 07:14:24 2018 +0500

    Merge pull request #1 from multitheftauto/master

    Merge master into custom_ifp_animations

commit d38e68ecedaf5cc51824f4586e958d79a106477b
Author: Qais Patankar <qaisjp@gmail.com>
Date:   Wed Jun 6 23:41:34 2018 +0100

    Undo whitespace change

    (test commit)

commit 3114067f6de92f90e74516815e050459e2a01822
Author: idanish <danishroar@gmail.com>
Date:   Fri May 4 15:37:41 2018 +0500

    Added copyright comment, and added #pragma once to header files

commit cd5b1cd46c149d88e3206c7a514e1c077b906246
Author: idanish <danishroar@gmail.com>
Date:   Fri May 4 15:36:31 2018 +0500

    Added m_ prefix before member names and copyright comment at top.

commit a311d8d809b2180284a2108bb35eeac033043c9a
Author: idanish <danishroar@gmail.com>
Date:   Thu Apr 12 01:11:43 2018 +0500

    Fix warning c4150 when deleting Game SA interface

    Visual studio was generating a warning when calling delete operator on hierarchy and sequnece interface in Client Deathmatch, so replaced it with CAnimManager::DeleteCustomAnimHierarchyInterface and CAnimManager::DeleteCustomAnimSequenceInterface in CIFPAnimations::DeleteAnimations and CClientIFP::MoveSequencesWithDummies

    Also, applied source formatting

commit 90ba0443b752839922875b7d1783c0de2d3f1e39
Author: idanish <danishroar@gmail.com>
Date:   Wed Apr 11 23:35:59 2018 +0500

    Improved custom animation hooks for readability

    Rewrote HOOK_CAnimBlendAssocGroup_CopyAnimation in C++ for more clarity, it is shorter now, and thus more readable.

    Moved HOOK_CAnimBlendAssoc_destructor to CMultiplayerSA_HookDestructors.cpp

commit db75cd6073a9b3fc308bebe21b2b52569adc23dc
Author: idanish <danishroar@gmail.com>
Date:   Wed Apr 11 15:39:59 2018 +0500

    Removed IFP mutexes from CClientGame and CClientPed

    They were not needed. I used them because I was in doubt whether GTA:SA is using a secondary thread. I confirmed that it's not using another thread with the help of SharedUtil::IsMainThread() method.
    - Suggested by Jusonex

commit c54b8549ea831a42955c700033b4974ab610b554
Author: idanish <danishroar@gmail.com>
Date:   Fri Apr 6 17:19:45 2018 +0500

    Removed GameSA includes from Client Deathmatch and minor code improvements

    Replaced GameSA includes with interfaces
    - Suggested by Jusonex

    Removed #pragma from CIFPEngine.h
    eRestoreType is now passed by const reference in CIFPEngine::EngineRestoreAnimation

commit 43f90fe49a6b7de2852f9eb7f197ac511cc23d4d
Author: idanish <danishroar@gmail.com>
Date:   Thu Apr 5 14:51:55 2018 +0500

    Code quality improvements

    Replaced uint32_t, int32_t, and int16_t with std::* from <cstdint>
    - Suggested by Necktrox

    Used std::find_if in CClientIFP::GetAnimationHierarchy
    & improved iterator loops by using
    for (auto& Animation : m_pIFPAnimations->vecAnimations)  in CClientIFP::ReadIFPVersion2 and CClientIFP::ReadIFPVersion1
    - earlier suggested by sbx320

    Replaced std::string with SString.

    Changed CIFPAnimations::SIFPAnimation::pSequencesMemory type to BYTE*. Removed casting where this member of struct was accessed.

    Used const where applicable in CClientIFP.cpp.

    Renamed ConvertStringToMapKey to ConvertStringToKey.

    Applied source formatting again

commit 6ec9bcca61793b050c197fd4934e56c16566be32
Author: idanish <danishroar@gmail.com>
Date:   Wed Apr 4 16:18:00 2018 +0500

    Rewrote CFileReader and some code review improvements

    CFileReader is using ifstream to load file into std::vector. No more dynamic memory allocation.
    &
    replaced std::vector::push_back with std::vector::emplace_back in CElementDeleter::OnClientIFPElementDestroy
    & Removed empty destructor from CClientIFP and empty constructor from CIFPAnimations
    - Suggested by Necktrox

    Used for (auto& pPed : m_setOfPedPointers) for iterating in CClientGame::OnClientIFPUnload.
    &
    using std::find_if in CElementDeleter::DeleteIFP with a lambda function
    - Suggested by sbx320

    Removed #pragma once in CClientIFP.h and CIFPAnimations.h
    - Suggested by sbx320 and Necktrox

commit e467f13c7039112456619c22226e67c4047833ee
Author: idanish <danishroar@gmail.com>
Date:   Wed Apr 4 06:15:24 2018 +0500

    Restored CStaticFunctionDefinitions::GUIMoveToBack

    Three lines got removed from this function while solving conflicts, so restored them back.

commit a45bf99dd3a36c337d99cceb904c9bf457d98386
Merge: dc8ef5c57 554a27d5b
Author: saml1er <10183157+saml1er@users.noreply.github.com>
Date:   Wed Apr 4 04:18:44 2018 +0500

    Merge branch 'master' into custom_ifp_animations

commit dc8ef5c57f8d558f6b230caad31cb26670de1cc1
Author: idanish <danishroar@gmail.com>
Date:   Wed Apr 4 03:55:45 2018 +0500

    Fix source formatting

commit 9a6f6ae84207251a90a0fb6bf04deb60144a2e09
Merge: e29b13a9c d7649ba5d
Author: idanish <danishroar@gmail.com>
Date:   Wed Apr 4 03:39:22 2018 +0500

    Merge branch 'test_custom_ifp_animations'

    # Conflicts:
    #	Client/game_sa/CAnimBlendAssocGroupSA.cpp
    #	Client/game_sa/CAnimBlendAssocGroupSA.h
    #	Client/game_sa/CAnimBlendHierarchySA.cpp
    #	Client/game_sa/CAnimBlendHierarchySA.h
    #	Client/game_sa/CAnimBlendSequenceSA.h
    #	Client/game_sa/CAnimBlendStaticAssociationSA.cpp
    #	Client/game_sa/CAnimBlendStaticAssociationSA.h
    #	Client/game_sa/CAnimBlockSA.h
    #	Client/game_sa/CAnimManagerSA.cpp
    #	Client/game_sa/CAnimManagerSA.h
    #	Client/mods/deathmatch/logic/CClientGame.cpp
    #	Client/mods/deathmatch/logic/CClientGame.h
    #	Client/mods/deathmatch/logic/CClientPed.cpp
    #	Client/mods/deathmatch/logic/CClientPed.h
    #	Client/mods/deathmatch/logic/CElementDeleter.cpp
    #	Client/mods/deathmatch/logic/CElementDeleter.h
    #	Client/mods/deathmatch/logic/CResource.cpp
    #	Client/mods/deathmatch/logic/CResource.h
    #	Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
    #	Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
    #	Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
    #	Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
    #	Client/multiplayer_sa/CMultiplayerSA.cpp
    #	Client/multiplayer_sa/CMultiplayerSA.h
    #	Client/multiplayer_sa/CMultiplayerSA_FixBadAnimId.cpp
    #	Client/sdk/game/CAnimBlendAssocGroup.h
    #	Client/sdk/game/CAnimBlendHierarchy.h
    #	Client/sdk/game/CAnimBlock.h
    #	Client/sdk/game/CAnimManager.h
    #	Client/sdk/game/CGame.h
    #	Client/sdk/multiplayer/CMultiplayer.h

commit d7649ba5d14c777017af85c930c912da1a14b8bc
Author: idanish <danishroar@gmail.com>
Date:   Wed Apr 4 02:50:33 2018 +0500

    Fix engineIFPLoad failure on resource multiple restarts

    IFP was failing to load after restarting resource multiple times, because it was removed from map in CElementDeleter::DeleteIFP which caused a small delay in ms. Now, it will be removed from map when it's added to element deleter list, so engineLoadIFP won't fail because the element with the same block name does not exist in map anymore.

commit 79c2463112936030cea81150dc7f69d7efded887
Merge: e1226844b 84655ef3f
Author: Code Nulls <danishroar@gmail.com>
Date:   Sun Apr 1 19:49:02 2018 +0500

    Merge pull request #8 from saml1er/custom_ifp_animations

    Custom ifp animations ( mergeable to master )

commit 84655ef3ff8c983eea590bbc021ce7a2f6acd321
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 19:42:46 2018 +0500

    Disabled console and removed printf

commit 11fe6531cd181ca79a14f519f00ff1b532ee5bfb
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 16:21:26 2018 +0500

    Used Hungarian notation for naming structs and enums

commit d38b4ecd71657a69be70497df24b35163029e314
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 15:31:49 2018 +0500

    [ FIX ] Compiling in release mode caused crash on CAnimBlendAssoc_destructor

commit e1226844bdafef53583880e5e8ed33297766204a
Merge: 1dfadb528 dae8c8569
Author: Code Nulls <danishroar@gmail.com>
Date:   Sun Apr 1 14:24:47 2018 +0500

    Merge pull request #7 from saml1er/custom_ifp_animations

    Custom ifp animations ( Everything is complete )

commit dae8c856909fd2cfbb2ba42fa5d8ec8083d29fb1
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 14:16:12 2018 +0500

    Removed 2 unused functions in CGame and CGameSA

commit 98ccb35a85a3b6e9f3de66e15e9a74d83344da08
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 12:25:25 2018 +0500

    Removed unsed GetClientPedByClump from CClientEntity

commit 66b9cd1886dfe5957c73a8640e34f8a4f94d6f82
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 11:55:06 2018 +0500

    Replaced Animations map is now thread-safe in CClientPed

commit a5ddb6ea930709bdce498bab7dab4454781afa91
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 11:22:09 2018 +0500

    Improved code design for CAnimBlendStaticAssociation

commit 7be4f2bf78254cdae51a637618dab055700277c6
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 09:20:24 2018 +0500

    Implemented thread synchronization for maps and set

commit ee3b7b1e66b6c6a555919b1b8fe2b0ebef226596
Author: idanish <danishroar@gmail.com>
Date:   Sun Apr 1 09:18:38 2018 +0500

    Moved Get functions to header in CAnimManagerSA

commit 3f4e3945d14e40ccbe8a16713ee78e486fd8167f
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 31 18:44:37 2018 +0500

    [FIX] Unloading IFP will allow gateway animation to play instead of custom
    Custom animation was not playing if you unloaded IFP. I used a shared_ptr to fix this problem. Also, unloading IFP resulted in looped animations to play gateway animation instead of custom, so fixed that as well.

commit 679982da2a78c68e0a3292bc84eec15b3dd205ec
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 31 18:41:12 2018 +0500

    Optimized std::map key for performance.

commit 91d3ea881cdcec7ce5bf35120e2e399c741312f5
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 30 09:35:15 2018 +0500

    [ FIX ] engineReplaceAnimation fails if block is not loaded

commit 5966687111e31e948bf12109f8e592a599032e18
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 30 09:34:37 2018 +0500

    Moved raw memory access to Game SA

commit a7b1011aa50672002256947dc5ca65e13cbd234b
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 29 15:20:51 2018 +0500

    Code design improvement in CIFPAnimations::DeleteAnimations

commit 015fd3994ad2f333ccce634ab2c5366476b59d19
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 29 15:19:48 2018 +0500

    Added CIFPEngine which contains most logic for Lua IFP functions

commit 1dfadb5280f8235f3a01d5e1e9f56ba3f56e329d
Merge: f4d1c5566 8bbd104de
Author: Code Nulls <danishroar@gmail.com>
Date:   Thu Mar 29 09:18:04 2018 +0500

    Merge pull request #6 from saml1er/custom_ifp_animations

    Custom ifp animations ( Improved Code Design )

commit 8bbd104de6831e61197c1054e5cb8ea0c1f4ea13
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 29 09:01:37 2018 +0500

    Added new functions to CAnimManager for CClientIFP

commit 1330cb4085952a7b7e947510a1341a0a4f664f58
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 29 08:58:08 2018 +0500

    Improved code design of CFileReader

commit 1d9eb2bf32256074abd222a8c723e3a403e5fcb9
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 29 08:55:22 2018 +0500

    Moved CIFPAnimations to deathmatch/logic

commit 63b17a4ab6475485b8eb739ee4fb2a78a48a4679
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 29 08:54:20 2018 +0500

    Removed unused files

commit 7f8ace6f8e27a3222bb30e48eb81f4b5097f685f
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 29 08:53:26 2018 +0500

    Removed IFPLoader include

commit 997ec7da6d53bd0c4689ec7a7ddda406988d0999
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 28 10:02:08 2018 +0500

    Improved overall code quality. Methods are even more shorter now.

commit c2a41954b9d5a6a1309014e64c7ff65336bb410e
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 28 03:52:30 2018 +0500

    Improved CClientIFP design even more and some optimizations
    The code design was really bad. Methods were very long which made them hard to understand. Now, they are readable.

commit 42e2109e3f6f6f6834b66c318fc8414fc84716c1
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 27 23:38:29 2018 +0500

    Improved IFP Readers, both Version 1 and 2.

commit c6e089f557578087218653ab2866d8ba09b06c58
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 27 23:08:20 2018 +0500

    Added PraseSequenceVersion1 and PraseSequenceVersion2

commit 7dc2f6e42552fb867c31165383d2e871875502ee
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 27 06:36:59 2018 +0500

    used iterator in ReadIFPVersion2 instead of C loop

commit 5ba567dfdfed7399c970407d54127f4506f4b618
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 27 06:18:31 2018 +0500

    Improved key frames reading logic for IFP Version 2

commit b5caa137ec40edaf29c268cfd9804a71562909ae
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 27 04:29:46 2018 +0500

    Improved code readability. Still more improvement needed.

commit 3e25495259b3e188556809b92c2c8ec97ac0728c
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 27 04:28:45 2018 +0500

    Moved structs and enums to CClientIFP class

commit 412a42a99e816746acf769a367fcb49df46c0e84
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 27 04:28:01 2018 +0500

    Added IFP_Animation struct and removed unused members.

commit 7b2394cfff8b5784607aa0f91d38281af6c7e468
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 26 10:02:19 2018 +0500

    Removed isIFPLoaded checks

commit 6243ca4ee7c4975a920926759c878c6aa696c4a2
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 26 10:02:01 2018 +0500

    Removed printf

commit a64710d99b9fc4966393ddb1f996bcc80809e713
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 26 09:24:23 2018 +0500

    Removed useless function calls in DeleteElementSpecial

commit 7cf982b35a132c645e0ca98ac1b75cc226c6d5ee
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 26 06:33:02 2018 +0500

    Using shared_ptr for CIFPAnimations

commit 63398afd6bc9877347ad6f75696621f19358ab2d
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 26 06:31:50 2018 +0500

    Created CIFPAnimations class for keeping IFP animations only

commit 19f1156642ce9544efc48585df26bbd7d0c72235
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 25 05:15:54 2018 +0500

    Replaced raw pointer with shared_ptr for CClientIFP

commit 19aae472f8f553b3c32709d600eb774fb5fb1bdf
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 25 05:15:07 2018 +0500

    Added IS_IFP macro

commit 6e8065929f1af6e39fc2b96caad421f0a1c08cbe
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 07:53:12 2018 +0500

    Added InsertAnimationDummySequence with new parameters

commit 85de6ed18ea20c35fe334815207a9d82cc2dcda7
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 07:52:44 2018 +0500

    Used factory pattern for Animation hierarchy and sequence

commit 2b6170b8d151c6fe5bc385de33ed27f2a7576a1f
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 07:52:11 2018 +0500

    Added GetCustomAnimBlendHierarchy and GetCustomAnimBlendSequence

commit 61b6232e0e7fdd326ce860f27b54bce84bc4a1ad
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 07:51:50 2018 +0500

    Added GetCustomAnimBlendHierarchy and GetCustomAnimBlendSequence

commit ce30759ba940b42b2996e7f6c15b5fd20c6ba831
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 07:51:11 2018 +0500

    Removed destructor

commit ee23cd90c886a46646f1ea82265479e2980440b0
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 07:50:53 2018 +0500

    Added animation hierarchy functions

commit 7a6146d2f96e139cce6568e1c0184c645351d494
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 04:40:58 2018 +0500

    Used Factory pattern for CAnimBlendSequenceSAInterface

commit 991df8cfba44936eddef9daf35cf2fef75b3e042
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 04:39:58 2018 +0500

    added GetAnimBlendSequence

commit 80638dd6975e28c6a809900584bd3a7e0f065d02
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 04:39:31 2018 +0500

    Added GetAnimBlendSequence

commit d5e33c4d16062c50f978b94cabe68ae97a030dbf
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 24 04:39:05 2018 +0500

    Added functions for CAnimBlendSequence and SA

commit f4d1c55661820025dea197af36bd6f4d2e96a4a3
Merge: cc41b2714 cc5b9ed0a
Author: Code Nulls <danishroar@gmail.com>
Date:   Thu Mar 22 03:15:13 2018 +0500

    Merge pull request #5 from saml1er/custom_ifp_animations

    Custom ifp animations [Fixed unloading]

commit cc5b9ed0a55310a549b973e0a6df2a468dd6befa
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 22 03:09:06 2018 +0500

    Removed CAnimBlendAssoc_Hierarchy_Constructor hook and handler

commit e557b629da6dc01d8178b29f167d1487ed887c17
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 22 02:43:12 2018 +0500

    Completed BlendAnimationHierarchy and CAnimBlendAssoc_Constructor
    These two hooks are meant to work in the same way. We can use anyone we wish to. BlendAnimationHierarchy is much cleaner and easy to understand, so let's use that one. Keep in mind that these two hooks get triggered for setPedAnimation only. They have nothing to do with AddAnimation and AddAniamtionAndSync

commit bb4ed1218ffb69a03f9809e75e0b699c312f6e49
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 22 02:40:58 2018 +0500

    Removed iAnimationSearchReferences.

commit 16ed6f584ff9081dd94a75e8e30349ca69afc472
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 08:04:19 2018 +0500

    Fixed unload crash. IFP is unloaded by checking references now.

commit c60a3b24970e68a5f9e7dc17aa669b33129b2868
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 08:03:15 2018 +0500

    UnloadIFP calls DeleteIFPAnimations now and renamed iAnimSearchRef

commit 8a672263d4180216373a502610149682fb265562
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 08:01:41 2018 +0500

    Removed static for iAnimationSearchReferences

commit e127b3c02b8b740293a96a59508f2c7301c3dd10
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 08:01:12 2018 +0500

    ReplaceAnimation checks whether IFP is loaded or not

commit 495220b50f7541da310b1ab796283b7c078ca395
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 08:00:01 2018 +0500

    changed UnloadIFPAnimations to DeleteIFPAnimations

commit a550ae1a67d1abe74458ec56e7b25fbec5c4dbb7
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 05:07:45 2018 +0500

    GetAnimationHierarchy loop breaks after hierarchy is found

commit 65fdfe771eb65572c7115108711db793178799b3
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 05:01:44 2018 +0500

    s_iAnimationSearchReferences is checked before unloading IFP anims

commit 44121e8eab3a1228d7a457f4674315645adcc4b1
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 05:01:14 2018 +0500

    added isIFPLoaded and s_iAnimationSearchReferences to CClientIFP

commit 3b1acd745bf55b6a2d4c912dde460a7222457b74
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 02:53:18 2018 +0500

    custom animation associations are kept in map for setPedAnimation

commit f85b8f5d7e04c190c18f8bc572a29d05063af402
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 21 02:51:52 2018 +0500

    inlined functions and added IFPAnimationsPointer functions

commit c5ee5dad0bcdbb1b91cca7c3edf3d5a7ec0bf5ee
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 20 21:02:54 2018 +0500

    CopyAnimation handler now modifies pOutIFPAnimations.

commit 47ea23346bb5dc8f4572fa29d8462c82f693356f
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 20 21:01:52 2018 +0500

    Fixed CopyAnim hook and added mapOfCustomAnimationAssociations and its functions.

commit fee333ba0d9b3048542a2819d10894668863d29a
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 20 21:00:11 2018 +0500

    Changed getReplacedAnimation return type to SReplacedAnimation *

commit f4258debe2a9d6de3da29092ba5d2ab68b92108f
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 20 20:59:18 2018 +0500

    added GetIFPAnimationsPointer
    This function will get a pointer to SIFPAnimations struct of the IFP

commit cb453c63088864baa7ef408de2f20a96efa5fe50
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 20 02:04:51 2018 +0500

    Added CAnimBlendAssociation Contructor and Destructor handler
    This is for properly unloading IFP using SIFPAnimations struct.

commit aab794092b6caa1bef2fc16c416fa118aa2e1e45
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 19 21:12:34 2018 +0500

    Moved custom animation hooks to a separate file

commit 16a9c55344eec843fec226151e943b062353d91f
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 19 20:05:31 2018 +0500

    [WIP] modifed CopyAnimation hook for SIFPAnimations
    This is needed for unloading IFP. We'll use this to increment and decrement iReferences in SIFPAnimations when an animation association is created and destroyed respectively.

commit 90e784ffd985df2ce57fad2905d7e1a6efb97001
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 19 20:00:26 2018 +0500

    changed CopyAnimation handler prototype and added SIFPAnimatins

commit f271bd505aad17b083d2b84b1c9af94ee576c785
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 19 19:59:36 2018 +0500

    Added include guard and removed prototypes with CAnimBlock in them

commit 44b516e23c7e1882f9bf1eb5c03d0e3c762f440a
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 19 19:58:49 2018 +0500

    added SIFPAnimations and removed a member from IFP_Animation

commit 8c9535ed6e1148138ae979e12d43e53d3fa920d8
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 19 19:57:48 2018 +0500

    Animations are stored in SIFPAnimations struct now

commit 10506ea017582cf515b36b8f2f2255a56b30ddf3
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 19 19:56:37 2018 +0500

    added a new parameter and changed return type of AssocGroupCopyAnimation

    Added SIFPAnimations ** as a new parameter and changed the return type to bool for both ( static and none static ) handlers of AssocGroupCopyAnimation

commit d84dc88d820c66833c433f93dbbcd9153679d18c
Author: idanish <danishroar@gmail.com>
Date:   Mon Mar 19 19:48:20 2018 +0500

    just added some padding, nothing special

commit 3c44bcc28ded03a1a78481c022c9c9fdee5a9ef5
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 16 23:30:24 2018 +0500

    added a check in GetAnimationHierarchy whether IFP is loaded or not

commit cc41b271408d446219e157a6bf385e4e41a8e2a6
Merge: c3fb1aaa1 b8a92b079
Author: Code Nulls <danishroar@gmail.com>
Date:   Fri Mar 16 12:02:22 2018 +0500

    Merge pull request #4 from saml1er/custom_ifp_animations

    Custom ifp animations

commit b8a92b0797d16d03c27130a3d582f8d3589c6a29
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 16 11:52:57 2018 +0500

    engineReplaceAnimation and engineRestoreAnimation is complete

commit 54c1a03824a472ebea5519e8dcd6da26c3ac72aa
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 16 11:51:25 2018 +0500

    IFP pointer is removed first from map then onClientIFPUnload is called

commit f4691ad73760221e452b2faf9b2d2d8737679977
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 16 11:49:48 2018 +0500

    added GetResourceIFPRoot inline function

commit 4ed6ef96aa7ac32fb124ad70b49ad5d5595b8959
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 16 11:46:00 2018 +0500

    added missing member pLinkPtr to Hierarchy interface

commit fa75a7bb3fc7e452bd8a39b3a2a80d5e1f19db06
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 16 11:45:35 2018 +0500

    Added missing members to CAnimBlockSAInterface

commit c3fb1aaa1e91957eba5e81089a039d67a9305e26
Merge: 64ba51c27 222bfe992
Author: Code Nulls <danishroar@gmail.com>
Date:   Thu Mar 15 01:15:05 2018 +0500

    Merge pull request #3 from saml1er/custom_ifp_animations

    Custom ifp animations

commit 222bfe992bff15822229504a6fdce6e79cdedaab
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 15 01:09:06 2018 +0500

    No longer using global variables in animation hooks

commit d9027b5d3f08321831411c5dfa662c72a00cdcc1
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 14 22:16:50 2018 +0500

    Static association is initialized within AssocGroupCopyAnimationHandler
    The typedef "hCAnimBlendStaticAssociation_Init" needs to deleted for production code. We need to properly use factory method.

commit bd58fa4304a079752e6ad2c70bfb9a7bfec6957f
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 14 22:14:55 2018 +0500

    Static association is created and destroyed within CopyAnimation hook

commit 1ad24fefc61330e1a5d7e15e698bab0dfa0084ec
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 14 22:05:24 2018 +0500

    added typedef for CAnimBlendStaticAssociation::FreeSequenceArray

commit 62b3d09e4aed3cb660d5a56b4a5e174020ba1c99
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 14 14:45:34 2018 +0500

    Created a new AssocGroupCopyAnimation handler

commit 16947656d46fae23b716904c790869fffbc24b2a
Author: idanish <danishroar@gmail.com>
Date:   Wed Mar 14 14:43:04 2018 +0500

    Added constexpr getAnimAssocGroupInterface function.

commit 9b578f9b9975669b05ad89ca27684b72c0094381
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 13 23:03:32 2018 +0500

    optimized CopyAnimation hook for saving tons of RAM
    If we created a new static association for every player for every single animation then it means for 1000 players, the memory might exceed 400mb, that's a lot. Why not destroy the static association when we copy the animation from it? That's exactly what's happening in the hook now.

commit e17b895494817360850c28a9da883d6cddc6c788
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 13 14:34:02 2018 +0500

    Added ability to replace GTA internal animations.
    Modified AddAnimation, AddAnimationAndSync, and CopyAnimation for replacing GTA internal animations with custom animations. We'll need to create our own static association when engineReplaceAnimation is called and use that static association for a specific ped/player to play our custom animation instead.

commit 2600653d4ee4da6633cdcbfc5d0f27e2742e93d1
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 13 14:29:48 2018 +0500

    Removed code from AddAnimationHandler and AddAnimationAndSyncHandler
    The code worked perfectly except for custom CopyAnimation function, if we tried to rewrite this function, it would crash.

commit af38b5fdb97fde0992e93b46534eab427c49476d
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 13 14:26:51 2018 +0500

    Removed CopyAnimation hook in InitHooks_FixBadAnimId

commit 5c0f65a5897c8d29c069b7a7ef7fc4f68d565ecd
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 10 12:17:33 2018 +0500

    Rewrote animation hooks properly in CClientGame and CMultiplayerSA
    I renamed BlendAnimation hook to BlendAnimationHierarchy because now it's hooking a different BlendAnimation function that takes an animation hierarchy as argument. Also, I separated AddAnimation and AddAnimationAndSync hooks and their handlers. Now, they work independently. Also, there was a problem with AddAnimationAndSync hook in CMultiplayerSA.cpp, I fixed the return of the hook.

commit 13989456644148a683eabfa00ff8b7e5ed94610d
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 10 08:55:22 2018 +0500

    [FIX] Fixed AddAnimation hook and disabled AddAnimationAndSync hook.
    I used Original code for AddAnimation hook in CClientGame::AddAnimationHandler. It works well. Now, it's time to create our own CAnimBlendAssociationSAInterface instead of using CopyAnimation. I'll need to enable AddAnimationAndSync hook as well because this is called for almost every internal GTA animation.

commit 64ba51c27e797558cc0c6602a1d6431fb78b109f
Merge: aa722ff6b 7e4ad6c02
Author: Code Nulls <danishroar@gmail.com>
Date:   Thu Mar 8 16:04:18 2018 +0500

    Merge pull request #2 from saml1er/custom_ifp_animations

    Working custom IFP animations

commit 7e4ad6c02e195d77f8e853074887087b7d5a3d3f
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 15:57:45 2018 +0500

    Removed CClient Ped pointer map functions

commit 7f18adcba409b8a8c00b54c222ae59a13741822e
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 15:57:17 2018 +0500

    enabled AddAnimation hook

commit b0157a8091544e2780012a9265ace39e1088fce3
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 15:57:07 2018 +0500

    Animation name is now checked in engineLoadIFP whether the hierarchy exists or not

commit d153d3bb4699212fabbb8798d3b8902c80443ebc
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 15:56:30 2018 +0500

    Fixes in ModelRequestCallBack and CClientPed constructor and destructor.
    Removed code for inserting and remove clump from map in ModelRequestCallBack. Also, CClientPed is inserted into map in constructor call and removed when destructor is called.

commit c529467b95683fd0ad9c1df16343b0cdc3c4f638
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 15:54:09 2018 +0500

    Added new functions for finding CClientPed by clump and used it in BlendAnimationHandler

commit f1313232426182be5d966918e9258e1e031007de
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 15:51:13 2018 +0500

    [BUGGY] Added a new function GetclientPedByClump, but causes crash sometimes

commit ecb3dc5158d956a2f5af07930ac423c8481c4cbd
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 15:50:35 2018 +0500

    Removed CClientPed pointer map functions

commit 2259c87a01d8b8cca0edc208778e123ba997ace9
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 06:13:41 2018 +0500

    Block name is now checked when loading IFP.
    Before you could load many IFPs with same block name and it would cause memory leaks, now it's fixed.

commit a9a8066e9c154cb09be713b538107cfaac2bff0d
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 8 06:11:31 2018 +0500

    [FIX] unloadIFP function works good now.

commit 76f2d0228be6a4186734e6ee75bf7ffbc65792b3
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 6 07:34:47 2018 +0500

    setPedAnimation finally works for playing custom animations. Both GTA VC and SA have been tested.

commit a467ae9bcf00b54c148cfc8867266e098839aded
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 6 07:32:26 2018 +0500

    changed BlendAnimationHandler hook resturn type

commit c39f14ca48297c1698e7de2d488bffcbefc7d2fd
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 6 07:31:54 2018 +0500

    BlendAnimation hook has been changed to BlendAnimation_Hierarchy hook because that is only triggered when setPedAnimation is called. Commented AddAnimation hook for now, it can be used for engineRestoreAnimation and engineReplaceAnimation along with AddAnimationAndSync hook

commit 357acfc5940de6fe78d58cf94096eb720fcd09bc
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 6 07:29:32 2018 +0500

    added a Name member to IFP_Animation struct for keeping the animation name

commit 05289e1862cc3265c40e9d286324b699eb4d1056
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 6 07:28:43 2018 +0500

    [FIX] Fixed custom animations crashing by changing keyframes memory allocator from malloc to OLD_CMemoryMgr_Malloc which is GTA SA function

commit ac2ef96e7999eed6eaa8b241f882be374678364d
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 6 07:26:57 2018 +0500

    pInterface variable is initialized to nullptr in GetAnimStaticAssociation

commit a97d89a6c674b99ae76d5e82034a484547d7618f
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 6 07:26:25 2018 +0500

    change pAnimBlendNodesSequenceArray type from int * to DWORD * in CAnimBlendStaticAssociationSA

commit 6037280cc1149542c5c99cb6aa7b21f7431507c5
Author: idanish <danishroar@gmail.com>
Date:   Tue Mar 6 07:25:43 2018 +0500

    fixed bRunningCompressed in CAnimBlendHierarchySAInterface

commit d8337a5387c772457ddeaf231b5d37dba8d0a48f
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 21:46:07 2018 +0500

    changed BlendAnimation hook to BlendAnimation_Hierarchy and hooks works fine. It is called when you execute setPedAnimation from client lua. This is where we can play custom animation

commit aa722ff6bf269b154ec93d3b3eeb05e561f3ac34
Merge: ceb5663a9 80aec0e2e
Author: Code Nulls <danishroar@gmail.com>
Date:   Sun Mar 4 12:40:39 2018 +0500

    Merge pull request #1 from saml1er/custom_ifp_animations

    Custom ifp animations

commit 80aec0e2e5f74df6a8a614b5c38e1da81baf56f9
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:28:59 2018 +0500

    added IFP function prototypes and a map container for retrieving IFP pointer by custom IFP block name

commit c1d7814bf3790c63bf27bb06df753480b57470a7
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:28:10 2018 +0500

    added a boolean for checking next animation whether it's custom or not in CClientPed::CClientPed. Renamed PedClump function calls to PedPointer functions

commit 333ff156232832e81a1782cf91738f75869f5479
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:26:50 2018 +0500

    remove PedClump map functions to PedPointer map functions. Also added GetWayBlockName and GetGateWayAnimationName

commit 9de077492697ae5c9898b678569f7da0b08007f1
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:25:58 2018 +0500

    custom IFP pointer is removed from map container when unloaded.

commit 0ba8e13784bd1b05777d25ad13a04fa3c91baf9f
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:25:12 2018 +0500

    added new functions for adding IFP pointer to map and checks for playing custom animation, not complete though. Custom animation is checked nicely, but isGateWayAnimationHierarchy function is not working properly.

commit acf46a7968a5e39ed98678fc17c6fec53561f4b1
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:22:20 2018 +0500

    IFP pointer is inserted to map if IFP is loaded sucessfully

commit df06f100b0a0e539dd8fc21c0c57dd9cef2204db
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:21:14 2018 +0500

    Modified setPedAnimation to play custom animation

commit b44dfc1389bb599b7abe8e6c88907c5c9dfd8213
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:20:39 2018 +0500

    added new functions isNextAnimationCustom, setNextAnimationCustom, and setNextAnimationNormal

commit bf5e7dc99ab903415d4032d4e94601f3b6296ceb
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 12:14:36 2018 +0500

    added GetGateWayAnimationName and GetGateWayBlockName. Renamed PedClump to PedPointer of m_mapofPedPointers' functions

commit d4b20ddccdb98247f2a6c666c444db26c802bb4a
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 06:00:11 2018 +0500

    [FIX] Memory of dummy sequences' frames was not being freed for IFP Version 2. Now, it's being freed

commit 9af78eacda16cc0db47e5bacd5142676baa0ac19
Author: idanish <danishroar@gmail.com>
Date:   Sun Mar 4 02:34:08 2018 +0500

    [FIX] Memory was not being freed properly for IFP Version 2, fixed it by adding a check. Also the loop for sequences in unloadIFP was incorrect, fixed that as well. Tested by checking the pointers and frees the memory properly now

commit d64f8b3bddb8e236530c1659d28215deb9779fb9
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 09:55:42 2018 +0500

    [BAD DESIGN] Implemented temporary UnloadIFP function for unloading IFPs while testing. Also, using malloc instead of OLD_CMemoryMgr_Malloc.

commit 1983a2ae907e9c127fdfbed6046f2113c5b7a2be
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 09:53:54 2018 +0500

    [IMPORTANT] Fixed heap corruption by adding int32_t to IFP_ANIM struct and fixed IFP_Animation struct.

commit 25e3a3e1ec60c52e3d28255c4665aecd6837b040
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 09:48:05 2018 +0500

    fixed private variables

commit e727d192abaafc82c7526286dd3f9448557659d7
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 04:16:02 2018 +0500

    [BAD DESIGN] added IFP loader. It works properly, but the design is horrible. We'll need to properly rewrite it according to MTA's coding guidelines. Also, there is no function for unloading IFP, so yeah there are memory leaks. Dynamic memory allocation is used for sequeneces and key frames only, so freeing this memory is important.

commit 556bcec5b8a66f5edb61a20f3fef55b620c5d034
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 02:23:08 2018 +0500

    commented printf in CClient::LoadIFP and CClient::UnloadIFP

commit 6e3d7d17e0fda6b39a780af42daf477e66aa1e08
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 02:22:12 2018 +0500

    moved GATEWAY_ANIMATION_NAME from global space into CAnimManagerSA class. Also, renamed it to m_kGateWayAnimationName.

commit eb23760730a59b9bcebf3f9e11e0f80e29c60d1e
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 00:22:32 2018 +0500

    [NOT TESTED] isGateWayAnimationHierarchy is called in AddAnimationHandler for checking and playing custom animation, but it is not tested because IFP reader needs to be added asap.

commit b5a6198775177466f4ba01c661c9af752d55be09
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 00:20:58 2018 +0500

    added GetAnimStaticAssociation prototype to CAnimManagerSA class and added gateway animation constant, value is set to "run_wuzi" for gateway animation

commit 098da77e70bfe48e3e0d9d1c02f63f0f837a4a44
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 00:19:47 2018 +0500

    fixed GetAnimAssociation function and renamed it to GetAnimstaticAssociation, also implemented isGateWayAnimationHierarchy

commit da68248435723c07e7b358a8a3fb2a9b8cfff43a
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 00:16:35 2018 +0500

    added isGateWayAnimationHierarchy prototype to class

commit e2bf58c2f767f86670aff6abf1e01dc492970b29
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 00:14:46 2018 +0500

    completed CAnimBlendStaticAssociationSAInterface class members by adding missing vTable, nNumBlendNodes, and pAnimBlendNodesSequeceArray

commit 1514322775e41d8d8b367b5ac61f41008bc0b8c4
Author: idanish <danishroar@gmail.com>
Date:   Sat Mar 3 00:13:20 2018 +0500

    changed iHashKey type from int to unsigned int since it's generated using CKeyGen::GetUpperCaseKey

commit f90ff66f19fcdb3ccb346889f3d095f4daae2869
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 2 18:50:43 2018 +0500

    added CClientIFP class, but the functions in there are pretty much empty

commit 1483f612cb632a28eea2e8d4fb41e8f6dea14ca0
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 2 18:49:54 2018 +0500

    added additional parameter to engineLoadIFP for custom block name

commit 4fddf9685cefbd19fd4e616f803806dee8692f2c
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 2 17:07:48 2018 +0500

    added scripting function engineLoadIFP for loading IFP on client.
    CClientIFP::LoadIFP is empty for now.

commit 26210bce07c80cdd351bf064e5b91e137b485960
Author: idanish <danishroar@gmail.com>
Date:   Fri Mar 2 17:06:13 2018 +0500

    added IFP entity

commit ceb5663a92312e51b2a8815cad66d00b35d5c07d
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 20:56:57 2018 +0500

    correct CClientPed * is returned from GetClientPedFromClumpMap to check to whom the clump belongs and what animation to play, it can be a custom animation as well.

commit c931b4c5a52eae94eb00a2351cc6cfa78be7fe07
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 20:54:17 2018 +0500

    In ModelRequestCallback, old clump is removed from CAnimManagerSA::m_mapOfPedClumps and new clump  is inserted into the map

commit 7705414638bacd7e158a3839d071f2423a8bfa79
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 20:52:45 2018 +0500

    added 3 new functions for finding the correct CClientPed * in a map of  Ped clumps.

commit ff8e9b953b49347e504de26353724e74bea9b0e4
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 20:51:00 2018 +0500

    Removed hCAnimBlendAssocGroup_CopyAnimation typedef

commit 76940cc6a4641bfa754dda972c62991a66e0000e
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 07:38:23 2018 +0500

    Using factory method for access association group, instead of ugly direct memory access

commit fe9e27b5f0d495124288fc9cc0e7a1d410f24fc8
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 07:37:06 2018 +0500

    added CreateAnimBlendAssocGroup function, also fixed tiny bits of formatting

commit d097ada190b58afd484057263b49b793168480a1
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 07:36:14 2018 +0500

    added CreateAnimBlendAssocGroup and getAnimAssocGroupInterface functions

commit 26dc2b31f9f81c49d15d24b7400ad670448f23cd
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 07:35:17 2018 +0500

    removed a space, nothing else

commit 6b1a4dbd994e44611968ad0f450b1102729aa322
Author: idanish <danishroar@gmail.com>
Date:   Thu Mar 1 02:53:57 2018 +0500

    removed 2 instructions in HOOK_CAnimManager_AddAnimation, because they were not needed

commit 6b6cff25b533ef0bc2d57010c2806373ce0caa7b
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 13:50:14 2018 +0500

    Modified AddAnimation hook to skip CopyAnimation function call, if m_pAddanimationHandler is nullptr/NULL then normal function flow executes to avoid crash

commit 8fe6bc45204ad5c434809266275fda0539a5e1f0
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 13:48:34 2018 +0500

    Aligned all function prototypes properly to match StaticAddAnimationHandler prototype

commit 0eb708016c7ac40862df6eac295a308d44ee800c
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 13:47:04 2018 +0500

    changed CAnimBlendAssociation * to CAnimBlendAssociationSAInterface *

commit bba1a39013ab5d37c44727d82fac9d2e9acad953
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 04:56:08 2018 +0500

    added typedef of CAnimBlendAssocGroup::CopyAnimation and changed return type of StaticAddAnimationHandler and AddAnimationHandler to CAnimBlendAssociation *

commit d860cb8de47ca8c5796406731f0bac80e8cb7c4f
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 04:54:45 2018 +0500

    added CopyAnimation function

commit dba18b616fecfcab80ef77fcdafb97357d65fada
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 04:54:11 2018 +0500

    Animation is copied using CopyAnimation function and the result is returned by AddAnimationHandler

commit 377195368f8564780d169ed5dbaf1337baa7524d
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 04:53:17 2018 +0500

    changed return type of AddAnimationHandler to CAnimBlendAssociation *

commit 80a7554415c2fca59aa4bd62575a281a2ea7ab2f
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 04:52:22 2018 +0500

    added CopyAnimation function

commit 86d070dde6861440221eccc56357493996812788
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 04:49:16 2018 +0500

    added a new function "CopyAnimation."

commit 894b4f6336e45042f89a0728d61aaaea7269f8e0
Author: idanish <danishroar@gmail.com>
Date:   Wed Feb 28 04:48:04 2018 +0500

    Displays Console. I'm only using it for testing

# Only use pull requests to submit patches! Use [the bug tracker](https://bugs.multitheftauto.com) to report bugs, or [the forum](https://forum.mtasa.com) to ask for help!

Before you go ahead and create a pull request, please make sure:

* [ ] [your code follows the coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines)
* [ ] your commit messages are informative ("update file.cpp" is unhelpful. "fix missing model in getVehicleNameFromModel" is helpful)

Thank you!
